### PR TITLE
Update, having run commons-builder build.

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/everypolitician/commons-builder.git
-  revision: 9e60cea0a38abc18040634eb3e5782b87f2b26a9
+  revision: e69eda8ad2a26953459cdd5f0a8a2c2634f0e2dc
   specs:
     commons-builder (0.1.0)
       rest-client (~> 2.0.2)

--- a/build_output.txt
+++ b/build_output.txt
@@ -1,0 +1,5 @@
+WARNING: the district 제주특별자치도 제주시갑 (Q50249398) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)
+WARNING: the district 경기도 고양시갑 (Q50242265) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)
+WARNING: the district 서울특별시 종로구 (Q50241354) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)
+WARNING: the district 부산광역시 금정구 (Q50242833) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)
+WARNING: the district 세종특별자치시 (Q50243082) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)

--- a/legislative/Q494162/Q22971549/popolo-m17n.json
+++ b/legislative/Q494162/Q22971549/popolo-m17n.json
@@ -2,6 +2,98 @@
   "persons": [
     {
       "name": {
+        "lang:ko_KR": "강창일",
+        "lang:en_US": "Kang Chang-il"
+      },
+      "id": "Q10855142",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q10855142"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/kangci52"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:ko_KR": "심상정",
+        "lang:en_US": "Sim Sang-jung"
+      },
+      "id": "Q11255427",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q11255427"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/simsangjung"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:ko_KR": "정세균",
+        "lang:en_US": "Chung Sye-kyun"
+      },
+      "id": "Q11270093",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q11270093"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/peopleinside2012"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:ko_KR": "박맹우",
+        "lang:en_US": "Bak Maeng-woo"
+      },
+      "id": "Q11986047",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q11986047"
+        }
+      ],
+      "links": [
+
+      ]
+    },
+    {
+      "name": {
+        "lang:ko_KR": "김세연",
+        "lang:en_US": "Kim Se-yeon"
+      },
+      "id": "Q16080285",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q16080285"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/100006028696877"
+        }
+      ]
+    },
+    {
+      "name": {
         "lang:ko_KR": "이수혁",
         "lang:en_US": "Lee Soo-hyuck"
       },
@@ -31,6 +123,25 @@
       "links": [
 
       ]
+    },
+    {
+      "name": {
+        "lang:ko_KR": "이해찬",
+        "lang:en_US": "Lee Hae Chan"
+      },
+      "id": "Q319920",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q319920"
+        }
+      ],
+      "links": [
+        {
+          "note": "facebook",
+          "url": "https://www.facebook.com/lhc21net"
+        }
+      ]
     }
   ],
   "organizations": [
@@ -47,7 +158,52 @@
           "identifier": "Q494162"
         }
       ],
-      "area_id": "Q884"
+      "area_id": "Q884",
+      "seat_counts": {
+        "Q14850694": "300"
+      }
+    },
+    {
+      "name": {
+        "lang:ko_KR": "더불어민주당",
+        "lang:en_US": "Democratic Party of Korea"
+      },
+      "id": "Q15978686",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q15978686"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:ko_KR": "자유한국당",
+        "lang:en_US": "Liberty Korea Party"
+      },
+      "id": "Q20916",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q20916"
+        }
+      ]
+    },
+    {
+      "name": {
+        "lang:ko_KR": "정의당 (대한민국)",
+        "lang:en_US": "Justice Party (South Korea)"
+      },
+      "id": "Q487520",
+      "classification": "party",
+      "identifiers": [
+        {
+          "scheme": "wikidata",
+          "identifier": "Q487520"
+        }
+      ]
     }
   ],
   "areas": [
@@ -55,10 +211,102 @@
   ],
   "memberships": [
     {
+      "id": "http://www.wikidata.org/entity/statement/Q10855142-FCB3F230-352D-4C79-8674-230E02736BDD",
+      "person_id": "Q10855142",
+      "on_behalf_of_id": "Q15978686",
+      "organization_id": "Q494162",
+      "area_id": "Q50249398",
+      "start_date": "2016-05-30",
+      "role_superclass_code": "Q486839",
+      "role_superclass": {
+        "lang:ko_KR": "국회의원",
+        "lang:en_US": "member of parliament"
+      },
+      "role_code": "Q14850694",
+      "role": {
+        "lang:ko_KR": "대한민국의 국회의원",
+        "lang:en_US": "Member of National Assembly of South Korea"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q11255427-15085B10-1928-48BD-BF15-27801C4AB334",
+      "person_id": "Q11255427",
+      "on_behalf_of_id": "Q487520",
+      "organization_id": "Q494162",
+      "area_id": "Q50242265",
+      "start_date": "2016-05-30",
+      "role_superclass_code": "Q486839",
+      "role_superclass": {
+        "lang:ko_KR": "국회의원",
+        "lang:en_US": "member of parliament"
+      },
+      "role_code": "Q14850694",
+      "role": {
+        "lang:ko_KR": "대한민국의 국회의원",
+        "lang:en_US": "Member of National Assembly of South Korea"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q11270093-35F1865C-89FD-43B2-92F4-3B22E3CDC76B",
+      "person_id": "Q11270093",
+      "on_behalf_of_id": "Q15978686",
+      "organization_id": "Q494162",
+      "area_id": "Q50241354",
+      "start_date": "2016-05-30",
+      "role_superclass_code": "Q486839",
+      "role_superclass": {
+        "lang:ko_KR": "국회의원",
+        "lang:en_US": "member of parliament"
+      },
+      "role_code": "Q14850694",
+      "role": {
+        "lang:ko_KR": "대한민국의 국회의원",
+        "lang:en_US": "Member of National Assembly of South Korea"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q11986047-248048f1-4e73-27a7-3da0-7322bdfe7311",
+      "person_id": "Q11986047",
+      "organization_id": "Q494162",
+      "role_superclass_code": "Q486839",
+      "role_superclass": {
+        "lang:ko_KR": "국회의원",
+        "lang:en_US": "member of parliament"
+      },
+      "role_code": "Q14850694",
+      "role": {
+        "lang:ko_KR": "대한민국의 국회의원",
+        "lang:en_US": "Member of National Assembly of South Korea"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q16080285-38BA3B74-87F3-46E3-B12C-F8E82D841821",
+      "person_id": "Q16080285",
+      "on_behalf_of_id": "Q20916",
+      "organization_id": "Q494162",
+      "area_id": "Q50242833",
+      "start_date": "2016-05-30",
+      "role_superclass_code": "Q486839",
+      "role_superclass": {
+        "lang:ko_KR": "국회의원",
+        "lang:en_US": "member of parliament"
+      },
+      "role_code": "Q14850694",
+      "role": {
+        "lang:ko_KR": "대한민국의 국회의원",
+        "lang:en_US": "Member of National Assembly of South Korea"
+      }
+    },
+    {
       "id": "http://www.wikidata.org/entity/statement/Q22974711-a95844ae-44b0-d855-37e0-5c81bf1aafc0",
       "person_id": "Q22974711",
       "organization_id": "Q494162",
       "start_date": "2017-06-01",
+      "role_superclass_code": "Q486839",
+      "role_superclass": {
+        "lang:ko_KR": "국회의원",
+        "lang:en_US": "member of parliament"
+      },
       "role_code": "Q14850694",
       "role": {
         "lang:ko_KR": "대한민국의 국회의원",
@@ -69,6 +317,28 @@
       "id": "http://www.wikidata.org/entity/statement/Q30093075-21955e80-4b61-95ec-bd31-1093dec5c3d1",
       "person_id": "Q30093075",
       "organization_id": "Q494162",
+      "role_superclass_code": "Q486839",
+      "role_superclass": {
+        "lang:ko_KR": "국회의원",
+        "lang:en_US": "member of parliament"
+      },
+      "role_code": "Q14850694",
+      "role": {
+        "lang:ko_KR": "대한민국의 국회의원",
+        "lang:en_US": "Member of National Assembly of South Korea"
+      }
+    },
+    {
+      "id": "http://www.wikidata.org/entity/statement/Q319920-E5662C5C-BCC6-481C-991C-E95A0DC90D55",
+      "person_id": "Q319920",
+      "organization_id": "Q494162",
+      "area_id": "Q50243082",
+      "start_date": "2016-05-30",
+      "role_superclass_code": "Q486839",
+      "role_superclass": {
+        "lang:ko_KR": "국회의원",
+        "lang:en_US": "member of parliament"
+      },
       "role_code": "Q14850694",
       "role": {
         "lang:ko_KR": "대한민국의 국회의원",

--- a/legislative/Q494162/Q22971549/query-results.json
+++ b/legislative/Q494162/Q22971549/query-results.json
@@ -1,9 +1,510 @@
 {
   "head" : {
-    "vars" : [ "statement", "item", "name_ko", "name_en", "party", "party_name_ko", "party_name_en", "district", "district_name_ko", "district_name_en", "role", "role_ko", "role_en", "start", "end", "facebook", "org", "org_ko", "org_en", "org_jurisdiction" ]
+    "vars" : [ "statement", "item", "name_ko", "name_en", "party", "party_name_ko", "party_name_en", "district", "district_name_ko", "district_name_en", "role", "role_ko", "role_en", "role_superclass", "role_superclass_ko", "role_superclass_en", "start", "end", "facebook", "org", "org_ko", "org_en", "org_jurisdiction", "org_seat_count" ]
   },
   "results" : {
     "bindings" : [ {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15978686"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Democratic Party of Korea"
+      },
+      "party_name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "더불어민주당"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q10855142-FCB3F230-352D-4C79-8674-230E02736BDD"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50249398"
+      },
+      "district_name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "제주특별자치도 제주시갑"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q486839"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of parliament"
+      },
+      "role_superclass_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "국회의원"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14850694"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of National Assembly of South Korea"
+      },
+      "role_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국의 국회의원"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q10855142"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kang Chang-il"
+      },
+      "name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "강창일"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q494162"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly"
+      },
+      "org_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국 국회"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q884"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "300"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "kangci52"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q487520"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Justice Party (South Korea)"
+      },
+      "party_name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "정의당 (대한민국)"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q11255427-15085B10-1928-48BD-BF15-27801C4AB334"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50242265"
+      },
+      "district_name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "경기도 고양시갑"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q486839"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of parliament"
+      },
+      "role_superclass_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "국회의원"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14850694"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of National Assembly of South Korea"
+      },
+      "role_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국의 국회의원"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11255427"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sim Sang-jung"
+      },
+      "name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "심상정"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q494162"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly"
+      },
+      "org_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국 국회"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q884"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "300"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "simsangjung"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q15978686"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Democratic Party of Korea"
+      },
+      "party_name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "더불어민주당"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q11270093-35F1865C-89FD-43B2-92F4-3B22E3CDC76B"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50241354"
+      },
+      "district_name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "서울특별시 종로구"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q486839"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of parliament"
+      },
+      "role_superclass_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "국회의원"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14850694"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of National Assembly of South Korea"
+      },
+      "role_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국의 국회의원"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11270093"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Chung Sye-kyun"
+      },
+      "name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "정세균"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q494162"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly"
+      },
+      "org_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국 국회"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q884"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "300"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "peopleinside2012"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Jongno, Seoul"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q11986047-248048f1-4e73-27a7-3da0-7322bdfe7311"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q486839"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of parliament"
+      },
+      "role_superclass_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "국회의원"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14850694"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of National Assembly of South Korea"
+      },
+      "role_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국의 국회의원"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q11986047"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Bak Maeng-woo"
+      },
+      "name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "박맹우"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q494162"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly"
+      },
+      "org_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국 국회"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q884"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "300"
+      }
+    }, {
+      "party" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q20916"
+      },
+      "party_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Liberty Korea Party"
+      },
+      "party_name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "자유한국당"
+      },
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q16080285-38BA3B74-87F3-46E3-B12C-F8E82D841821"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50242833"
+      },
+      "district_name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "부산광역시 금정구"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q486839"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of parliament"
+      },
+      "role_superclass_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "국회의원"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14850694"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of National Assembly of South Korea"
+      },
+      "role_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국의 국회의원"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q16080285"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Kim Se-yeon"
+      },
+      "name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "김세연"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q494162"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly"
+      },
+      "org_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국 국회"
+      },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q884"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "300"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "100006028696877"
+      }
+    }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q22974711-a95844ae-44b0-d855-37e0-5c81bf1aafc0"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q486839"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of parliament"
+      },
+      "role_superclass_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "국회의원"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q14850694"
@@ -46,13 +547,14 @@
         "type" : "literal",
         "value" : "대한민국 국회"
       },
-      "statement" : {
-        "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q22974711-a95844ae-44b0-d855-37e0-5c81bf1aafc0"
-      },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q884"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "300"
       },
       "start" : {
         "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
@@ -60,6 +562,24 @@
         "value" : "2017-06-01T00:00:00Z"
       }
     }, {
+      "statement" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/statement/Q30093075-21955e80-4b61-95ec-bd31-1093dec5c3d1"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q486839"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of parliament"
+      },
+      "role_superclass_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "국회의원"
+      },
       "role" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q14850694"
@@ -102,13 +622,107 @@
         "type" : "literal",
         "value" : "대한민국 국회"
       },
+      "org_jurisdiction" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q884"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "300"
+      }
+    }, {
       "statement" : {
         "type" : "uri",
-        "value" : "http://www.wikidata.org/entity/statement/Q30093075-21955e80-4b61-95ec-bd31-1093dec5c3d1"
+        "value" : "http://www.wikidata.org/entity/statement/Q319920-E5662C5C-BCC6-481C-991C-E95A0DC90D55"
+      },
+      "district" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q50243082"
+      },
+      "district_name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "세종특별자치시"
+      },
+      "role_superclass" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q486839"
+      },
+      "role_superclass_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "member of parliament"
+      },
+      "role_superclass_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "국회의원"
+      },
+      "role" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q14850694"
+      },
+      "role_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Member of National Assembly of South Korea"
+      },
+      "role_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국의 국회의원"
+      },
+      "item" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q319920"
+      },
+      "name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Lee Hae Chan"
+      },
+      "name_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "이해찬"
+      },
+      "org" : {
+        "type" : "uri",
+        "value" : "http://www.wikidata.org/entity/Q494162"
+      },
+      "org_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "National Assembly"
+      },
+      "org_ko" : {
+        "xml:lang" : "ko",
+        "type" : "literal",
+        "value" : "대한민국 국회"
       },
       "org_jurisdiction" : {
         "type" : "uri",
         "value" : "http://www.wikidata.org/entity/Q884"
+      },
+      "org_seat_count" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#decimal",
+        "type" : "literal",
+        "value" : "300"
+      },
+      "start" : {
+        "datatype" : "http://www.w3.org/2001/XMLSchema#dateTime",
+        "type" : "literal",
+        "value" : "2016-05-30T00:00:00Z"
+      },
+      "facebook" : {
+        "type" : "literal",
+        "value" : "lhc21net"
+      },
+      "district_name_en" : {
+        "xml:lang" : "en",
+        "type" : "literal",
+        "value" : "Sejong City"
       }
     } ]
   }

--- a/legislative/Q494162/Q22971549/query-used.rq
+++ b/legislative/Q494162/Q22971549/query-used.rq
@@ -3,64 +3,80 @@ SELECT ?statement
        ?party ?party_name_ko ?party_name_en
        ?district ?district_name_ko ?district_name_en
        ?role ?role_ko ?role_en
+       ?role_superclass ?role_superclass_ko ?role_superclass_en
        ?start ?end ?facebook
-       ?org ?org_ko ?org_en ?org_jurisdiction
+       ?org ?org_ko ?org_en ?org_jurisdiction ?org_seat_count
 WHERE {
   BIND(wd:Q14850694 as ?role) .
   BIND(wd:Q494162 as ?org) .
   OPTIONAL {
-        ?org rdfs:label ?org_ko
-        FILTER(LANG(?org_ko) = "ko")
-      }
+          ?org rdfs:label ?org_ko
+          FILTER(LANG(?org_ko) = "ko")
+        }
 OPTIONAL {
-        ?org rdfs:label ?org_en
-        FILTER(LANG(?org_en) = "en")
-      }
+          ?org rdfs:label ?org_en
+          FILTER(LANG(?org_en) = "en")
+        }
   OPTIONAL {
     ?org wdt:P1001 ?org_jurisdiction
   }
+  OPTIONAL {
+    ?org wdt:P1342 ?org_seat_count
+  }
   ?item p:P39 ?statement .
   OPTIONAL {
-        ?item rdfs:label ?name_ko
-        FILTER(LANG(?name_ko) = "ko")
-      }
+          ?item rdfs:label ?name_ko
+          FILTER(LANG(?name_ko) = "ko")
+        }
 OPTIONAL {
-        ?item rdfs:label ?name_en
-        FILTER(LANG(?name_en) = "en")
-      }
+          ?item rdfs:label ?name_en
+          FILTER(LANG(?name_en) = "en")
+        }
   ?statement ps:P39 ?role .
   OPTIONAL {
-        ?role rdfs:label ?role_ko
-        FILTER(LANG(?role_ko) = "ko")
-      }
+          ?role rdfs:label ?role_ko
+          FILTER(LANG(?role_ko) = "ko")
+        }
 OPTIONAL {
-        ?role rdfs:label ?role_en
-        FILTER(LANG(?role_en) = "en")
-      }
+          ?role rdfs:label ?role_en
+          FILTER(LANG(?role_en) = "en")
+        }
+  OPTIONAL {
+    ?role wdt:P279 ?role_superclass .
+    ?role_superclass wdt:P279+ wd:Q4175034
+    OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_ko
+          FILTER(LANG(?role_superclass_ko) = "ko")
+        }
+OPTIONAL {
+          ?role_superclass rdfs:label ?role_superclass_en
+          FILTER(LANG(?role_superclass_en) = "en")
+        }
+  }
   ?statement pq:P2937 wd:Q22971549 .
   OPTIONAL { ?statement pq:P580 ?start }
   OPTIONAL { ?statement pq:P582 ?end }
   OPTIONAL {
     ?statement pq:P768 ?district.
     OPTIONAL {
-        ?district rdfs:label ?district_name_ko
-        FILTER(LANG(?district_name_ko) = "ko")
-      }
+          ?district rdfs:label ?district_name_ko
+          FILTER(LANG(?district_name_ko) = "ko")
+        }
 OPTIONAL {
-        ?district rdfs:label ?district_name_en
-        FILTER(LANG(?district_name_en) = "en")
-      }
+          ?district rdfs:label ?district_name_en
+          FILTER(LANG(?district_name_en) = "en")
+        }
   }
   OPTIONAL {
     ?statement pq:P4100 ?party.
     OPTIONAL {
-        ?party rdfs:label ?party_name_ko
-        FILTER(LANG(?party_name_ko) = "ko")
-      }
+          ?party rdfs:label ?party_name_ko
+          FILTER(LANG(?party_name_ko) = "ko")
+        }
 OPTIONAL {
-        ?party rdfs:label ?party_name_en
-        FILTER(LANG(?party_name_en) = "en")
-      }
+          ?party rdfs:label ?party_name_en
+          FILTER(LANG(?party_name_en) = "en")
+        }
   }
   OPTIONAL { ?item wdt:P2013 ?facebook }
   


### PR DESCRIPTION
This is a simple run of `build` from `commons-builder`, pulling in recent changes from Wikidata. There'll be a follow-up PR with `generate_legislative_index` and `build` run, to pull in FLACS data. Output from the build script:

```
WARNING: the district 제주특별자치도 제주시갑 (Q50249398) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)
WARNING: the district 경기도 고양시갑 (Q50242265) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)
WARNING: the district 서울특별시 종로구 (Q50241354) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)
WARNING: the district 부산광역시 금정구 (Q50242833) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)
WARNING: the district 세종특별자치시 (Q50243082) wasn't found in the boundary data for position 대한민국의 국회의원 (Q14850694)
```

~~I guess @GeoWill might be able to help with the warnings?~~ (no boundaries yet, so to be expected)