### PR TITLE
Wikidata languages

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,6 +1,6 @@
 GIT
   remote: git://github.com/everypolitician/commons-builder.git
-  revision: 3a599cc3de36c740169e71f8ac4cf5c7cbe935d6
+  revision: 0e34a060ae8b124e4e1131bb540379ea1f5acccc
   specs:
     commons-builder (0.1.0)
       rest-client (~> 2.0.2)
@@ -8,7 +8,7 @@ GIT
 GEM
   remote: https://rubygems.org/
   specs:
-    domain_name (0.5.20170404)
+    domain_name (0.5.20180417)
       unf (>= 0.0.5, < 1.0.0)
     http-cookie (1.0.3)
       domain_name (~> 0.5)

--- a/config.json
+++ b/config.json
@@ -1,7 +1,7 @@
 {
-    "language_map": {
-      "lang:ko_KR": "ko",
-      "lang:en_US": "en"
-    },
-    "country_wikidata_id": "Q884"
+  "languages": [
+    "ko",
+    "en"
+  ],
+  "country_wikidata_id": "Q884"
 }

--- a/executive/Q12583023/current/popolo-m17n.json
+++ b/executive/Q12583023/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q12583022"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gangwon-do",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q12583547/current/popolo-m17n.json
+++ b/executive/Q12583547/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "남경필",
-        "lang:en_US": "Nam Kyung-pil"
+        "lang:ko": "남경필",
+        "lang:en": "Nam Kyung-pil"
       },
       "id": "Q12589755",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "경기도청",
-        "lang:en_US": "Gyeonggi Provincial Govenment"
+        "lang:ko": "경기도청",
+        "lang:en": "Gyeonggi Provincial Govenment"
       },
       "id": "Q12583547",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -68,8 +68,8 @@
         "Q12583545"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gyeonggi-do",
@@ -93,7 +93,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -112,13 +112,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q12583545",
       "role_superclass": {
-        "lang:ko_KR": "경기도지사",
-        "lang:en_US": "Governor of Gyeonggi Province"
+        "lang:ko": "경기도지사",
+        "lang:en": "Governor of Gyeonggi Province"
       },
       "role_code": "Q12583545",
       "role": {
-        "lang:ko_KR": "경기도지사",
-        "lang:en_US": "Governor of Gyeonggi Province"
+        "lang:ko": "경기도지사",
+        "lang:en": "Governor of Gyeonggi Province"
       }
     }
   ]

--- a/executive/Q12583737/current/popolo-m17n.json
+++ b/executive/Q12583737/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50619415"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gyeongsangbuk-do",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q12585108/current/popolo-m17n.json
+++ b/executive/Q12585108/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50616327"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Gwangju",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q12585780/current/popolo-m17n.json
+++ b/executive/Q12585780/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "문재인",
-        "lang:en_US": "Moon Jae-in"
+        "lang:ko": "문재인",
+        "lang:en": "Moon Jae-in"
       },
       "id": "Q21001",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "국무회의",
-        "lang:en_US": "State Council of South Korea"
+        "lang:ko": "국무회의",
+        "lang:en": "State Council of South Korea"
       },
       "id": "Q12585780",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -68,7 +68,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -87,13 +87,13 @@
       "start_date": "2017-05-10",
       "role_superclass_code": "Q6296418",
       "role_superclass": {
-        "lang:ko_KR": "대한민국의 대통령",
-        "lang:en_US": "President of South Korea"
+        "lang:ko": "대한민국의 대통령",
+        "lang:en": "President of South Korea"
       },
       "role_code": "Q6296418",
       "role": {
-        "lang:ko_KR": "대한민국의 대통령",
-        "lang:en_US": "President of South Korea"
+        "lang:ko": "대한민국의 대통령",
+        "lang:en": "President of South Korea"
       }
     }
   ]

--- a/executive/Q12613488/current/popolo-m17n.json
+++ b/executive/Q12613488/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50617475"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Incheon",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q12615100/current/popolo-m17n.json
+++ b/executive/Q12615100/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q12615101"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Jeollanam-do",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q12615114/current/popolo-m17n.json
+++ b/executive/Q12615114/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50619493"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Jeollabuk-do",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q12616502/current/popolo-m17n.json
+++ b/executive/Q12616502/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "원희룡",
-        "lang:en_US": "Won Hee-ryong"
+        "lang:ko": "원희룡",
+        "lang:en": "Won Hee-ryong"
       },
       "id": "Q8031676",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "제주특별자치도청",
-        "lang:en_US": "Jeju Self-governing Provincial Government"
+        "lang:ko": "제주특별자치도청",
+        "lang:en": "Jeju Self-governing Provincial Government"
       },
       "id": "Q12616502",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -68,8 +68,8 @@
         "Q50275066"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 특별자치도",
-        "lang:en_US": "Special Self-governing Province of South Korea"
+        "lang:ko": "대한민국의 특별자치도",
+        "lang:en": "Special Self-governing Province of South Korea"
       },
       "name": {
         "lang:en_US": "Jeju Special Self-Governing Province",
@@ -93,7 +93,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -112,13 +112,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q50275066",
       "role_superclass": {
-        "lang:ko_KR": "제주특별자치도지사",
-        "lang:en_US": "Governor of Jeju"
+        "lang:ko": "제주특별자치도지사",
+        "lang:en": "Governor of Jeju"
       },
       "role_code": "Q50275066",
       "role": {
-        "lang:ko_KR": "제주특별자치도지사",
-        "lang:en_US": "Governor of Jeju"
+        "lang:ko": "제주특별자치도지사",
+        "lang:en": "Governor of Jeju"
       }
     }
   ]

--- a/executive/Q12620195/current/popolo-m17n.json
+++ b/executive/Q12620195/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50619614"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Chungcheongnam-do",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q12620207/current/popolo-m17n.json
+++ b/executive/Q12620207/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50619326"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Chungcheongbuk-do",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q16093739/current/popolo-m17n.json
+++ b/executive/Q16093739/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50619685"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gyeongsangnam-do",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q16095354/current/popolo-m17n.json
+++ b/executive/Q16095354/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50614705"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Daegu",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q16095517/current/popolo-m17n.json
+++ b/executive/Q16095517/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50615886"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Daejeon",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q16097618/current/popolo-m17n.json
+++ b/executive/Q16097618/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "서병수",
-        "lang:en_US": "Suh Byung-soo"
+        "lang:ko": "서병수",
+        "lang:en": "Suh Byung-soo"
       },
       "id": "Q16083277",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "부산광역시청",
-        "lang:en_US": "Busan Metropolitan Government"
+        "lang:ko": "부산광역시청",
+        "lang:en": "Busan Metropolitan Government"
       },
       "id": "Q16097618",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -68,8 +68,8 @@
         "Q50265926"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Busan",
@@ -93,7 +93,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -112,13 +112,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q50265926",
       "role_superclass": {
-        "lang:ko_KR": "부산광역시장",
-        "lang:en_US": "Mayors of Busan"
+        "lang:ko": "부산광역시장",
+        "lang:en": "Mayors of Busan"
       },
       "role_code": "Q50265926",
       "role": {
-        "lang:ko_KR": "부산광역시장",
-        "lang:en_US": "Mayors of Busan"
+        "lang:ko": "부산광역시장",
+        "lang:en": "Mayors of Busan"
       }
     }
   ]

--- a/executive/Q16097915/current/popolo-m17n.json
+++ b/executive/Q16097915/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "이춘희 (1955년)",
-        "lang:en_US": "Lee Chunhee"
+        "lang:ko": "이춘희 (1955년)",
+        "lang:en": "Lee Chunhee"
       },
       "id": "Q12612939",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "세종특별자치시청",
-        "lang:en_US": "Sejong Special City Government"
+        "lang:ko": "세종특별자치시청",
+        "lang:en": "Sejong Special City Government"
       },
       "id": "Q16097915",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -68,8 +68,8 @@
         "Q50274663"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 특별자치시",
-        "lang:en_US": "special autonomous city in South Korea"
+        "lang:ko": "대한민국의 특별자치시",
+        "lang:en": "special autonomous city in South Korea"
       },
       "name": {
         "lang:en_US": "Sejong Special Self-Governing City",
@@ -93,7 +93,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -112,13 +112,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q50274663",
       "role_superclass": {
-        "lang:ko_KR": "세종특별자치시시장",
-        "lang:en_US": "Mayor of Sejong City"
+        "lang:ko": "세종특별자치시시장",
+        "lang:en": "Mayor of Sejong City"
       },
       "role_code": "Q50274663",
       "role": {
-        "lang:ko_KR": "세종특별자치시시장",
-        "lang:en_US": "Mayor of Sejong City"
+        "lang:ko": "세종특별자치시시장",
+        "lang:en": "Mayor of Sejong City"
       }
     }
   ]

--- a/executive/Q16099053/current/popolo-m17n.json
+++ b/executive/Q16099053/current/popolo-m17n.json
@@ -22,8 +22,8 @@
         "Q50619818"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Ulsan",
@@ -47,7 +47,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",

--- a/executive/Q623789/current/popolo-m17n.json
+++ b/executive/Q623789/current/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "박원순",
-        "lang:en_US": "Park Won-soon"
+        "lang:ko": "박원순",
+        "lang:en": "Park Won-soon"
       },
       "id": "Q22803",
       "identifiers": [
@@ -23,8 +23,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "서울특별시청",
-        "lang:en_US": "Seoul Metropolitan Government"
+        "lang:ko": "서울특별시청",
+        "lang:en": "Seoul Metropolitan Government"
       },
       "id": "Q623789",
       "classification": "branch",
@@ -38,8 +38,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -68,8 +68,8 @@
         "Q488289"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 특별시",
-        "lang:en_US": "special city of South Korea"
+        "lang:ko": "대한민국의 특별시",
+        "lang:en": "special city of South Korea"
       },
       "name": {
         "lang:en_US": "Seoul",
@@ -93,7 +93,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -112,13 +112,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q488289",
       "role_superclass": {
-        "lang:ko_KR": "서울특별시장",
-        "lang:en_US": "Mayor of Seoul"
+        "lang:ko": "서울특별시장",
+        "lang:en": "Mayor of Seoul"
       },
       "role_code": "Q488289",
       "role": {
-        "lang:ko_KR": "서울특별시장",
-        "lang:en_US": "Mayor of Seoul"
+        "lang:ko": "서울특별시장",
+        "lang:en": "Mayor of Seoul"
       }
     }
   ]

--- a/legislative/Q12601388/Q50798355/popolo-m17n.json
+++ b/legislative/Q12601388/Q50798355/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "이명희의 랄랄라"
+        "lang:ko": "이명희의 랄랄라"
       },
       "id": "Q21059873",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "강감창"
+        "lang:ko": "강감창"
       },
       "id": "Q21824767",
       "identifiers": [
@@ -35,7 +35,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이정훈"
+        "lang:ko": "이정훈"
       },
       "id": "Q50809802",
       "identifiers": [
@@ -50,7 +50,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "송재형"
+        "lang:ko": "송재형"
       },
       "id": "Q50809805",
       "identifiers": [
@@ -65,7 +65,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "양준욱"
+        "lang:ko": "양준욱"
       },
       "id": "Q50809808",
       "identifiers": [
@@ -80,7 +80,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박호근"
+        "lang:ko": "박호근"
       },
       "id": "Q50809827",
       "identifiers": [
@@ -95,7 +95,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "주찬식"
+        "lang:ko": "주찬식"
       },
       "id": "Q50809829",
       "identifiers": [
@@ -110,7 +110,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "남창진"
+        "lang:ko": "남창진"
       },
       "id": "Q50809831",
       "identifiers": [
@@ -125,7 +125,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "진두생"
+        "lang:ko": "진두생"
       },
       "id": "Q50809833",
       "identifiers": [
@@ -140,7 +140,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김영한"
+        "lang:ko": "김영한"
       },
       "id": "Q50809865",
       "identifiers": [
@@ -155,7 +155,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "최조웅"
+        "lang:ko": "최조웅"
       },
       "id": "Q50809866",
       "identifiers": [
@@ -172,8 +172,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "서울특별시의회",
-        "lang:en_US": "Seoul municipal council"
+        "lang:ko": "서울특별시의회",
+        "lang:en": "Seoul municipal council"
       },
       "id": "Q12601388",
       "classification": "branch",
@@ -190,8 +190,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -204,8 +204,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -234,8 +234,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "성동구제1선거구"
@@ -258,8 +258,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "노원구제1선거구"
@@ -282,8 +282,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "양천구제1선거구"
@@ -306,8 +306,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "송파구제6선거구"
@@ -330,8 +330,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "도봉구제1선거구"
@@ -354,8 +354,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강남구제4선거구"
@@ -378,8 +378,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "동작구제1선거구"
@@ -402,8 +402,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "은평구제1선거구"
@@ -426,8 +426,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "송파구제4선거구"
@@ -450,8 +450,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "영등포구제3선거구"
@@ -474,8 +474,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강남구제1선거구"
@@ -498,8 +498,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "서초구제4선거구"
@@ -522,8 +522,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "송파구제2선거구"
@@ -546,8 +546,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "성북구제2선거구"
@@ -570,8 +570,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "구로구제4선거구"
@@ -594,8 +594,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "성북구제4선거구"
@@ -618,8 +618,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "노원구제2선거구"
@@ -642,8 +642,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강북구제4선거구"
@@ -666,8 +666,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "마포구제2선거구"
@@ -690,8 +690,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "송파구제1선거구"
@@ -714,8 +714,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "중랑구제1선거구"
@@ -738,8 +738,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "중랑구제2선거구"
@@ -762,8 +762,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "구로구제1선거구"
@@ -786,8 +786,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강서구제1선거구"
@@ -810,8 +810,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "구로구제3선거구"
@@ -834,8 +834,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강남구제2선거구"
@@ -858,8 +858,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "서대문구제2선거구"
@@ -882,8 +882,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강남구제3선거구"
@@ -906,8 +906,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "동작구제3선거구"
@@ -930,8 +930,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "관악구제2선거구"
@@ -954,8 +954,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "은평구제3선거구"
@@ -978,8 +978,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "서초구제3선거구"
@@ -1002,8 +1002,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "중구제2선거구"
@@ -1026,8 +1026,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "성동구제3선거구"
@@ -1050,8 +1050,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "노원구제3선거구"
@@ -1074,8 +1074,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "송파구제5선거구"
@@ -1098,8 +1098,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "광진구제1선거구"
@@ -1122,8 +1122,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "중구제1선거구"
@@ -1146,8 +1146,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "동대문구제3선거구"
@@ -1170,8 +1170,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "노원구제6선거구"
@@ -1194,8 +1194,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "용산구제1선거구"
@@ -1218,8 +1218,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강서구제3선거구"
@@ -1242,8 +1242,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "은평구제2선거구"
@@ -1266,8 +1266,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "송파구제3선거구"
@@ -1290,8 +1290,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강동구제3선거구"
@@ -1314,8 +1314,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "금천구제1선거구"
@@ -1338,8 +1338,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강북구제2선거구"
@@ -1362,8 +1362,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "서대문구제3선거구"
@@ -1386,8 +1386,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강동구제1선거구"
@@ -1410,8 +1410,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "종로구제2선거구"
@@ -1434,8 +1434,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강동구제2선거구"
@@ -1458,8 +1458,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강북구제3선거구"
@@ -1482,8 +1482,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "도봉구제2선거구"
@@ -1506,8 +1506,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "동작구제4선거구"
@@ -1530,8 +1530,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "광진구제3선거구"
@@ -1554,8 +1554,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "성동구제4선거구"
@@ -1578,8 +1578,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "광진구제2선거구"
@@ -1602,8 +1602,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "서대문구제4선거구"
@@ -1626,8 +1626,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "서초구제2선거구"
@@ -1650,8 +1650,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "영등포구제4선거구"
@@ -1674,8 +1674,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강서구제4선거구"
@@ -1698,8 +1698,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "성동구제2선거구"
@@ -1722,8 +1722,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "동대문구제1선거구"
@@ -1746,8 +1746,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "중랑구제4선거구"
@@ -1770,8 +1770,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "중랑구제3선거구"
@@ -1794,8 +1794,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "마포구제3선거구"
@@ -1818,8 +1818,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "성북구제3선거구"
@@ -1842,8 +1842,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "관악구제4선거구"
@@ -1866,8 +1866,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "동대문구제2선거구"
@@ -1890,8 +1890,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "광진구제4선거구"
@@ -1914,8 +1914,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "구로구제2선거구"
@@ -1938,8 +1938,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강동구제4선거구"
@@ -1962,8 +1962,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "관악구제3선거구"
@@ -1986,8 +1986,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "노원구제4선거구"
@@ -2010,8 +2010,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "양천구제2선거구"
@@ -2034,8 +2034,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "서초구제1선거구"
@@ -2058,8 +2058,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "영등포구제2선거구"
@@ -2082,8 +2082,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "금천구제2선거구"
@@ -2106,8 +2106,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "성북구제1선거구"
@@ -2130,8 +2130,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "은평구제4선거구"
@@ -2154,8 +2154,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "영등포구제1선거구"
@@ -2178,8 +2178,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "관악구제1선거구"
@@ -2202,8 +2202,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "동대문구제4선거구"
@@ -2226,8 +2226,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "마포구제1선거구"
@@ -2250,8 +2250,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "마포구제4선거구"
@@ -2274,8 +2274,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "종로구제1선거구"
@@ -2298,8 +2298,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "양천구제4선거구"
@@ -2322,8 +2322,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "양천구제3선거구"
@@ -2346,8 +2346,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "노원구제5선거구"
@@ -2370,8 +2370,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "용산구제2선거구"
@@ -2394,8 +2394,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "도봉구제4선거구"
@@ -2418,8 +2418,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "동작구제2선거구"
@@ -2442,8 +2442,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "서대문구제1선거구"
@@ -2466,8 +2466,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강서구제2선거구"
@@ -2490,8 +2490,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "강북구제1선거구"
@@ -2514,8 +2514,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "도봉구제3선거구"
@@ -2538,8 +2538,8 @@
         "Q50257366"
       ],
       "type": {
-        "lang:ko_KR": "서울특별시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Seoul"
+        "lang:ko": "서울특별시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
         "lang:ko_KR": "서울특별시 비례대표 선거구"
@@ -2562,8 +2562,8 @@
         "Q488289"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 특별시",
-        "lang:en_US": "special city of South Korea"
+        "lang:ko": "대한민국의 특별시",
+        "lang:en": "special city of South Korea"
       },
       "name": {
         "lang:en_US": "Seoul",
@@ -2587,7 +2587,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -2606,13 +2606,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2624,13 +2624,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2642,13 +2642,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2660,13 +2660,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2678,13 +2678,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2696,13 +2696,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2714,13 +2714,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2732,13 +2732,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2750,13 +2750,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2768,13 +2768,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     },
     {
@@ -2786,13 +2786,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50257366",
       "role": {
-        "lang:ko_KR": "서울특별시의원동정",
-        "lang:en_US": "Seoul councilor"
+        "lang:ko": "서울특별시의원동정",
+        "lang:en": "Seoul councilor"
       }
     }
   ]

--- a/legislative/Q16093243/Q50798392/popolo-m17n.json
+++ b/legislative/Q16093243/Q50798392/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "김동일"
+        "lang:ko": "김동일"
       },
       "id": "Q50809438",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "한금석"
+        "lang:ko": "한금석"
       },
       "id": "Q50809440",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이기찬"
+        "lang:ko": "이기찬"
       },
       "id": "Q50809442",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "장세국"
+        "lang:ko": "장세국"
       },
       "id": "Q50809443",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박현창"
+        "lang:ko": "박현창"
       },
       "id": "Q50809444",
       "identifiers": [
@@ -77,7 +77,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "곽영승"
+        "lang:ko": "곽영승"
       },
       "id": "Q50809448",
       "identifiers": [
@@ -92,7 +92,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "최명서"
+        "lang:ko": "최명서"
       },
       "id": "Q50809453",
       "identifiers": [
@@ -110,7 +110,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "권석주"
+        "lang:ko": "권석주"
       },
       "id": "Q50809455",
       "identifiers": [
@@ -125,7 +125,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "진기엽"
+        "lang:ko": "진기엽"
       },
       "id": "Q50809458",
       "identifiers": [
@@ -143,7 +143,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "함종국"
+        "lang:ko": "함종국"
       },
       "id": "Q50809460",
       "identifiers": [
@@ -161,7 +161,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "유정선"
+        "lang:ko": "유정선"
       },
       "id": "Q50809887",
       "identifiers": [
@@ -178,8 +178,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "강원도의회",
-        "lang:en_US": "Gangwon Province municipal council"
+        "lang:ko": "강원도의회",
+        "lang:en": "Gangwon Province municipal council"
       },
       "id": "Q16093243",
       "classification": "branch",
@@ -196,8 +196,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -210,8 +210,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -240,8 +240,8 @@
         "Q12583022"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gangwon-do",
@@ -265,8 +265,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "횡성군제2선거구"
@@ -289,8 +289,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "평창군제2선거구"
@@ -313,8 +313,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "춘천시제4선거구"
@@ -337,8 +337,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "평창군제1선거구"
@@ -361,8 +361,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "동해시제2선거구"
@@ -385,8 +385,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "강릉시제3선거구"
@@ -409,8 +409,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "강릉시제1선거구"
@@ -433,8 +433,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "원주시제5선거구"
@@ -457,8 +457,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "원주시제4선거구"
@@ -481,8 +481,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "홍천군제1선거구"
@@ -505,8 +505,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "원주시제3선거구"
@@ -529,8 +529,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "원주시제2선거구"
@@ -553,8 +553,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "태백시제1선거구"
@@ -577,8 +577,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "양구군선거구"
@@ -601,8 +601,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "철원군제2선거구"
@@ -625,8 +625,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "고성군선거구"
@@ -649,8 +649,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "태백시제2선거구"
@@ -673,8 +673,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "정선군제2선거구"
@@ -697,8 +697,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "속초시제1선거구"
@@ -721,8 +721,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "삼척시제1선거구"
@@ -745,8 +745,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "속초시제2선거구"
@@ -769,8 +769,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "춘천시제3선거구"
@@ -793,8 +793,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "강릉시제4선거구"
@@ -817,8 +817,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "정선군제1선거구"
@@ -841,8 +841,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "춘천시제1선거구"
@@ -865,8 +865,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "홍천군제2선거구"
@@ -889,8 +889,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "횡성군제1선거구"
@@ -913,8 +913,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "화천군선거구"
@@ -937,8 +937,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "원주시제6선거구"
@@ -961,8 +961,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "삼척시제2선거구"
@@ -985,8 +985,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "영월군제1선거구"
@@ -1009,8 +1009,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "영월군제2선거구"
@@ -1033,8 +1033,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "동해시제1선거구"
@@ -1057,8 +1057,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "춘천시제5선거구"
@@ -1081,8 +1081,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "양양군선거구"
@@ -1105,8 +1105,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "원주시제1선거구"
@@ -1129,8 +1129,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "인제군선거구"
@@ -1153,8 +1153,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "철원군제1선거구"
@@ -1177,8 +1177,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "강릉시제2선거구"
@@ -1201,8 +1201,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "춘천시제2선거구"
@@ -1225,8 +1225,8 @@
         "Q50559021"
       ],
       "type": {
-        "lang:ko_KR": "강원도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gangwon Province"
+        "lang:ko": "강원도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
         "lang:ko_KR": "강원도 비례대표 선거구"
@@ -1249,7 +1249,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -1268,13 +1268,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1286,13 +1286,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1304,13 +1304,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1322,13 +1322,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1340,13 +1340,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1358,13 +1358,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1376,13 +1376,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1394,13 +1394,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1412,13 +1412,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1430,13 +1430,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     },
     {
@@ -1448,13 +1448,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559021",
       "role": {
-        "lang:ko_KR": "강원도의원동정",
-        "lang:en_US": "Gangwon Province councilor"
+        "lang:ko": "강원도의원동정",
+        "lang:en": "Gangwon Province councilor"
       }
     }
   ]

--- a/legislative/Q16093885/Q50798239/popolo-m17n.json
+++ b/legislative/Q16093885/Q50798239/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "장용훈"
+        "lang:ko": "장용훈"
       },
       "id": "Q50809308",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "황이주"
+        "lang:ko": "황이주"
       },
       "id": "Q50809310",
       "identifiers": [
@@ -35,7 +35,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박현국"
+        "lang:ko": "박현국"
       },
       "id": "Q50809312",
       "identifiers": [
@@ -50,7 +50,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "황재철"
+        "lang:ko": "황재철"
       },
       "id": "Q50809313",
       "identifiers": [
@@ -68,7 +68,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "남천희"
+        "lang:ko": "남천희"
       },
       "id": "Q50809314",
       "identifiers": [
@@ -86,7 +86,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "윤종도"
+        "lang:ko": "윤종도"
       },
       "id": "Q50809315",
       "identifiers": [
@@ -101,7 +101,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "최태림"
+        "lang:ko": "최태림"
       },
       "id": "Q50809316",
       "identifiers": [
@@ -116,7 +116,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김수문"
+        "lang:ko": "김수문"
       },
       "id": "Q50809317",
       "identifiers": [
@@ -131,7 +131,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "홍진규"
+        "lang:ko": "홍진규"
       },
       "id": "Q50809319",
       "identifiers": [
@@ -146,7 +146,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "곽경호"
+        "lang:ko": "곽경호"
       },
       "id": "Q50809322",
       "identifiers": [
@@ -161,7 +161,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김정숙"
+        "lang:ko": "김정숙"
       },
       "id": "Q50810420",
       "identifiers": [
@@ -178,8 +178,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "경상북도의회",
-        "lang:en_US": "North Gyeongsang Province municipal council"
+        "lang:ko": "경상북도의회",
+        "lang:en": "North Gyeongsang Province municipal council"
       },
       "id": "Q16093885",
       "classification": "branch",
@@ -196,8 +196,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -226,8 +226,8 @@
         "Q50619415"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gyeongsangbuk-do",
@@ -251,8 +251,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경산시제4선거구"
@@ -275,8 +275,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "예천군제1선거구"
@@ -299,8 +299,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "포항시제7선거구"
@@ -323,8 +323,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "안동시제2선거구"
@@ -347,8 +347,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "청송군선거구"
@@ -371,8 +371,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "문경시제1선거구"
@@ -395,8 +395,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "영양군선거구"
@@ -419,8 +419,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "봉화군선거구"
@@ -443,8 +443,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "포항시제5선거구"
@@ -467,8 +467,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "구미시제6선거구"
@@ -491,8 +491,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "포항시제3선거구"
@@ -515,8 +515,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "칠곡군제1선거구"
@@ -539,8 +539,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경산시제1선거구"
@@ -563,8 +563,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "문경시제2선거구"
@@ -587,8 +587,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경주시제2선거구"
@@ -611,8 +611,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "영주시제1선거구"
@@ -635,8 +635,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "포항시제1선거구"
@@ -659,8 +659,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "포항시제4선거구"
@@ -683,8 +683,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경주시제3선거구"
@@ -707,8 +707,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경주시제4선거구"
@@ -731,8 +731,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "군위군선거구"
@@ -755,8 +755,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "구미시제1선거구"
@@ -779,8 +779,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "구미시제5선거구"
@@ -803,8 +803,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "포항시제2선거구"
@@ -827,8 +827,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "상주시제2선거구"
@@ -851,8 +851,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "고령군선거구"
@@ -875,8 +875,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "구미시제3선거구"
@@ -899,8 +899,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "구미시제4선거구"
@@ -923,8 +923,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "칠곡군제2선거구"
@@ -947,8 +947,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "청도군제2선거구"
@@ -971,8 +971,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "안동시제3선거구"
@@ -995,8 +995,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "포항시제8선거구"
@@ -1019,8 +1019,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "구미시제2선거구"
@@ -1043,8 +1043,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "영천시제1선거구"
@@ -1067,8 +1067,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "영덕군선거구"
@@ -1091,8 +1091,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "예천군제2선거구"
@@ -1115,8 +1115,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경산시제3선거구"
@@ -1139,8 +1139,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경산시제2선거구"
@@ -1163,8 +1163,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "상주시제1선거구"
@@ -1187,8 +1187,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "영주시제2선거구"
@@ -1211,8 +1211,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "포항시제6선거구"
@@ -1235,8 +1235,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "청도군제1선거구"
@@ -1259,8 +1259,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "울진군제1선거구"
@@ -1283,8 +1283,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "울릉군선거구"
@@ -1307,8 +1307,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "의성군제1선거구"
@@ -1331,8 +1331,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "영천시제2선거구"
@@ -1355,8 +1355,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "김천시제1선거구"
@@ -1379,8 +1379,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "울진군제2선거구"
@@ -1403,8 +1403,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경주시제1선거구"
@@ -1427,8 +1427,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "안동시제1선거구"
@@ -1451,8 +1451,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "의성군제2선거구"
@@ -1475,8 +1475,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "성주군제1선거구"
@@ -1499,8 +1499,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "김천시제2선거구"
@@ -1523,8 +1523,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "성주군제2선거구"
@@ -1547,8 +1547,8 @@
         "Q50559328"
       ],
       "type": {
-        "lang:ko_KR": "경상북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Gyeongsang Province"
+        "lang:ko": "경상북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경상북도 비례대표 선거구"
@@ -1571,7 +1571,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -1590,13 +1590,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1608,13 +1608,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1625,13 +1625,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1643,13 +1643,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1661,13 +1661,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1678,13 +1678,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1696,13 +1696,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1714,13 +1714,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1732,13 +1732,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1750,13 +1750,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     },
     {
@@ -1768,13 +1768,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559328",
       "role": {
-        "lang:ko_KR": "경상북도의원동정",
-        "lang:en_US": "North Gyeongsang Province councilor"
+        "lang:ko": "경상북도의원동정",
+        "lang:en": "North Gyeongsang Province councilor"
       }
     }
   ]

--- a/legislative/Q16094335/Q50798291/popolo-m17n.json
+++ b/legislative/Q16094335/Q50798291/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "반재신"
+        "lang:ko": "반재신"
       },
       "id": "Q50277134",
       "identifiers": [
@@ -20,7 +20,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "조오섭"
+        "lang:ko": "조오섭"
       },
       "id": "Q50277387",
       "identifiers": [
@@ -38,7 +38,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "문상필"
+        "lang:ko": "문상필"
       },
       "id": "Q50277603",
       "identifiers": [
@@ -56,7 +56,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "전진숙"
+        "lang:ko": "전진숙"
       },
       "id": "Q50277742",
       "identifiers": [
@@ -74,7 +74,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김동찬"
+        "lang:ko": "김동찬"
       },
       "id": "Q50277958",
       "identifiers": [
@@ -89,7 +89,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이정현"
+        "lang:ko": "이정현"
       },
       "id": "Q50809535",
       "identifiers": [
@@ -104,7 +104,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "문태환"
+        "lang:ko": "문태환"
       },
       "id": "Q50809537",
       "identifiers": [
@@ -119,7 +119,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김옥자"
+        "lang:ko": "김옥자"
       },
       "id": "Q50809541",
       "identifiers": [
@@ -134,7 +134,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김민종"
+        "lang:ko": "김민종"
       },
       "id": "Q50809542",
       "identifiers": [
@@ -149,7 +149,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이은방"
+        "lang:ko": "이은방"
       },
       "id": "Q50809547",
       "identifiers": [
@@ -164,7 +164,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "서미정"
+        "lang:ko": "서미정"
       },
       "id": "Q50809879",
       "identifiers": [
@@ -181,8 +181,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "광주광역시의회",
-        "lang:en_US": "Gwangju municipal council"
+        "lang:ko": "광주광역시의회",
+        "lang:en": "Gwangju municipal council"
       },
       "id": "Q16094335",
       "classification": "branch",
@@ -199,8 +199,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -229,8 +229,8 @@
         "Q50616327"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Gwangju",
@@ -254,8 +254,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "북구제1선거구"
@@ -278,8 +278,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "북구제2선거구"
@@ -302,8 +302,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "북구제3선거구"
@@ -326,8 +326,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "북구제4선거구"
@@ -350,8 +350,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "광주광역시북구제5선거구"
@@ -374,8 +374,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "동구제2선거구"
@@ -398,8 +398,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "남구제1선거구"
@@ -422,8 +422,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "광산구제3선거구"
@@ -446,8 +446,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "동구제1선거구"
@@ -470,8 +470,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "광산구제1선거구"
@@ -494,8 +494,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "남구제3선거구"
@@ -518,8 +518,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "서구제1선거구"
@@ -542,8 +542,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "서구제3선거구"
@@ -566,8 +566,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "서구제4선거구"
@@ -590,8 +590,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "서구제2선거구"
@@ -614,8 +614,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "광산구제2선거구"
@@ -638,8 +638,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "북구제6선거구"
@@ -662,8 +662,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "남구제2선거구"
@@ -686,8 +686,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "광산구제4선거구"
@@ -710,8 +710,8 @@
         "Q50277114"
       ],
       "type": {
-        "lang:ko_KR": "광주광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gwangju"
+        "lang:ko": "광주광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
         "lang:ko_KR": "광주광역시 비례대표 선거구"
@@ -734,7 +734,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -753,13 +753,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -771,13 +771,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -789,13 +789,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -807,13 +807,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -825,13 +825,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -843,13 +843,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -861,13 +861,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -879,13 +879,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -897,13 +897,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -915,13 +915,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     },
     {
@@ -933,13 +933,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50277114",
       "role": {
-        "lang:ko_KR": "광주광역시의원동정",
-        "lang:en_US": "Gwangju councilor"
+        "lang:ko": "광주광역시의원동정",
+        "lang:en": "Gwangju councilor"
       }
     }
   ]

--- a/legislative/Q16094835/Q50798277/popolo-m17n.json
+++ b/legislative/Q16094835/Q50798277/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "류순철"
+        "lang:ko": "류순철"
       },
       "id": "Q50809282",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "안철우"
+        "lang:ko": "안철우"
       },
       "id": "Q50809290",
       "identifiers": [
@@ -35,7 +35,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "조선제"
+        "lang:ko": "조선제"
       },
       "id": "Q50809291",
       "identifiers": [
@@ -50,7 +50,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박우범"
+        "lang:ko": "박우범"
       },
       "id": "Q50809293",
       "identifiers": [
@@ -65,7 +65,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "진병영"
+        "lang:ko": "진병영"
       },
       "id": "Q50809295",
       "identifiers": [
@@ -80,7 +80,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박춘식"
+        "lang:ko": "박춘식"
       },
       "id": "Q50809298",
       "identifiers": [
@@ -95,7 +95,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이갑재"
+        "lang:ko": "이갑재"
       },
       "id": "Q50809300",
       "identifiers": [
@@ -110,7 +110,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "성경호"
+        "lang:ko": "성경호"
       },
       "id": "Q50809301",
       "identifiers": [
@@ -125,7 +125,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "정재환"
+        "lang:ko": "정재환"
       },
       "id": "Q50809305",
       "identifiers": [
@@ -140,7 +140,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박인"
+        "lang:ko": "박인"
       },
       "id": "Q50810083",
       "identifiers": [
@@ -155,7 +155,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이성애"
+        "lang:ko": "이성애"
       },
       "id": "Q50810084",
       "identifiers": [
@@ -172,8 +172,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "경상남도의회",
-        "lang:en_US": "South Gyeongsang Province municipal council"
+        "lang:ko": "경상남도의회",
+        "lang:en": "South Gyeongsang Province municipal council"
       },
       "id": "Q16094835",
       "classification": "branch",
@@ -190,8 +190,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -220,8 +220,8 @@
         "Q50619685"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gyeongsangnam-do",
@@ -245,8 +245,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "함양군선거구"
@@ -269,8 +269,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "진주시제4선거구"
@@ -293,8 +293,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "밀양시제2선거구"
@@ -317,8 +317,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "양산시제1선거구"
@@ -341,8 +341,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "통영시제1선거구"
@@ -365,8 +365,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제5선거구"
@@ -389,8 +389,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창녕군제1선거구"
@@ -413,8 +413,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "양산시제3선거구"
@@ -437,8 +437,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제11선거구"
@@ -461,8 +461,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "김해시제7선거구"
@@ -485,8 +485,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "김해시제3선거구"
@@ -509,8 +509,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "합천군선거구"
@@ -533,8 +533,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제10선거구"
@@ -557,8 +557,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "진주시제2선거구"
@@ -581,8 +581,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제3선거구"
@@ -605,8 +605,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "김해시제5선거구"
@@ -629,8 +629,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "거제시제3선거구"
@@ -653,8 +653,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창녕군제2선거구"
@@ -677,8 +677,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "김해시제2선거구"
@@ -701,8 +701,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "하동군선거구"
@@ -725,8 +725,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "통영시제2선거구"
@@ -749,8 +749,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "김해시제1선거구"
@@ -773,8 +773,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제9선거구"
@@ -797,8 +797,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "산청군선거구"
@@ -821,8 +821,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제7선거구"
@@ -845,8 +845,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "거창군제1선거구"
@@ -869,8 +869,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "거제시제1선거구"
@@ -893,8 +893,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "함안군제1선거구"
@@ -917,8 +917,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "사천시제1선거구"
@@ -941,8 +941,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제4선거구"
@@ -965,8 +965,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제6선거구"
@@ -989,8 +989,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "함안군제2선거구"
@@ -1013,8 +1013,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "진주시제1선거구"
@@ -1037,8 +1037,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "남해군선거구"
@@ -1061,8 +1061,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "거창군제2선거구"
@@ -1085,8 +1085,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제12선거구"
@@ -1109,8 +1109,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "고성군제2선거구"
@@ -1133,8 +1133,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "양산시제2선거구"
@@ -1157,8 +1157,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제1선거구"
@@ -1181,8 +1181,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "거제시제2선거구"
@@ -1205,8 +1205,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "밀양시제1선거구"
@@ -1229,8 +1229,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "진주시제3선거구"
@@ -1253,8 +1253,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "김해시제6선거구"
@@ -1277,8 +1277,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제8선거구"
@@ -1301,8 +1301,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "사천시제2선거구"
@@ -1325,8 +1325,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제13선거구"
@@ -1349,8 +1349,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "고성군제1선거구"
@@ -1373,8 +1373,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "김해시제4선거구"
@@ -1397,8 +1397,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "의령군선거구"
@@ -1421,8 +1421,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "창원시제2선거구"
@@ -1445,8 +1445,8 @@
         "Q50559353"
       ],
       "type": {
-        "lang:ko_KR": "경상남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Gyeongsang Province"
+        "lang:ko": "경상남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
         "lang:ko_KR": "경상남도 비례대표 선거구"
@@ -1469,7 +1469,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -1488,13 +1488,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1506,13 +1506,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1524,13 +1524,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1542,13 +1542,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1560,13 +1560,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1578,13 +1578,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1596,13 +1596,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1614,13 +1614,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1632,13 +1632,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1650,13 +1650,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     },
     {
@@ -1668,13 +1668,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559353",
       "role": {
-        "lang:ko_KR": "경상남도의원동정",
-        "lang:en_US": "South Gyeongsang Province councilor"
+        "lang:ko": "경상남도의원동정",
+        "lang:en": "South Gyeongsang Province councilor"
       }
     }
   ]

--- a/legislative/Q16095349/Q50798372/popolo-m17n.json
+++ b/legislative/Q16095349/Q50798372/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "오철환"
+        "lang:ko": "오철환"
       },
       "id": "Q16090356",
       "identifiers": [
@@ -20,7 +20,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "최재훈"
+        "lang:ko": "최재훈"
       },
       "id": "Q31178236",
       "identifiers": [
@@ -35,7 +35,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "조성제"
+        "lang:ko": "조성제"
       },
       "id": "Q50809624",
       "identifiers": [
@@ -50,7 +50,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이귀화"
+        "lang:ko": "이귀화"
       },
       "id": "Q50809628",
       "identifiers": [
@@ -65,7 +65,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "조홍철"
+        "lang:ko": "조홍철"
       },
       "id": "Q50809630",
       "identifiers": [
@@ -80,7 +80,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김재관"
+        "lang:ko": "김재관"
       },
       "id": "Q50809631",
       "identifiers": [
@@ -95,7 +95,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박상태"
+        "lang:ko": "박상태"
       },
       "id": "Q50809761",
       "identifiers": [
@@ -113,7 +113,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김원구"
+        "lang:ko": "김원구"
       },
       "id": "Q50809762",
       "identifiers": [
@@ -128,7 +128,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "배지숙"
+        "lang:ko": "배지숙"
       },
       "id": "Q50809764",
       "identifiers": [
@@ -146,7 +146,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "정순천"
+        "lang:ko": "정순천"
       },
       "id": "Q50809765",
       "identifiers": [
@@ -164,7 +164,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "차순자"
+        "lang:ko": "차순자"
       },
       "id": "Q50809872",
       "identifiers": [
@@ -184,8 +184,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "대구광역시의회",
-        "lang:en_US": "Daegu municipal council"
+        "lang:ko": "대구광역시의회",
+        "lang:en": "Daegu municipal council"
       },
       "id": "Q16095349",
       "classification": "branch",
@@ -202,8 +202,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -232,8 +232,8 @@
         "Q50614705"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Daegu",
@@ -257,8 +257,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "수성구제2선거구"
@@ -281,8 +281,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "달서구제4선거구"
@@ -305,8 +305,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "수성구제1선거구"
@@ -329,8 +329,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "중구제1선거구"
@@ -353,8 +353,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "북구제3선거구"
@@ -377,8 +377,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "수성구제3선거구"
@@ -401,8 +401,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "수성구제4선거구"
@@ -425,8 +425,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "달서구제6선거구"
@@ -449,8 +449,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "동구제1선거구"
@@ -473,8 +473,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "달서구제1선거구"
@@ -497,8 +497,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "북구제4선거구"
@@ -521,8 +521,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "중구제2선거구"
@@ -545,8 +545,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "동구제2선거구"
@@ -569,8 +569,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "남구제1선거구"
@@ -593,8 +593,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "북구제1선거구"
@@ -617,8 +617,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "달서구제2선거구"
@@ -641,8 +641,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "서구제2선거구"
@@ -665,8 +665,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "달서구제3선거구"
@@ -689,8 +689,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "북구제5선거구"
@@ -713,8 +713,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "동구제4선거구"
@@ -737,8 +737,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "서구제1선거구"
@@ -761,8 +761,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "달성군제2선거구"
@@ -785,8 +785,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "달서구제5선거구"
@@ -809,8 +809,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "달성군제1선거구"
@@ -833,8 +833,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "북구제2선거구"
@@ -857,8 +857,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "동구제3선거구"
@@ -881,8 +881,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "남구제2선거구"
@@ -905,8 +905,8 @@
         "Q50559494"
       ],
       "type": {
-        "lang:ko_KR": "대구광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daegu"
+        "lang:ko": "대구광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
         "lang:ko_KR": "대구광역시 비례대표 선거구"
@@ -929,7 +929,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -948,13 +948,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -966,13 +966,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -984,13 +984,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -1002,13 +1002,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -1020,13 +1020,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -1038,13 +1038,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -1056,13 +1056,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -1074,13 +1074,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -1092,13 +1092,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -1110,13 +1110,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     },
     {
@@ -1128,13 +1128,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559494",
       "role": {
-        "lang:ko_KR": "대구광역시의원동정",
-        "lang:en_US": "Daegu councilor"
+        "lang:ko": "대구광역시의원동정",
+        "lang:en": "Daegu councilor"
       }
     }
   ]

--- a/legislative/Q16095510/Q50797896/popolo-m17n.json
+++ b/legislative/Q16095510/Q50797896/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "박혜련",
-        "lang:en_US": "Park Hye-ryun"
+        "lang:ko": "박혜련",
+        "lang:en": "Park Hye-ryun"
       },
       "id": "Q17238174",
       "identifiers": [
@@ -18,8 +18,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "최선희",
-        "lang:en_US": "Choe Son Hui"
+        "lang:ko": "최선희",
+        "lang:en": "Choe Son Hui"
       },
       "id": "Q30436217",
       "identifiers": [
@@ -34,7 +34,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박희진"
+        "lang:ko": "박희진"
       },
       "id": "Q50809507",
       "identifiers": [
@@ -52,7 +52,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "심현영"
+        "lang:ko": "심현영"
       },
       "id": "Q50809508",
       "identifiers": [
@@ -67,7 +67,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박병철"
+        "lang:ko": "박병철"
       },
       "id": "Q50809509",
       "identifiers": [
@@ -85,7 +85,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "송대윤"
+        "lang:ko": "송대윤"
       },
       "id": "Q50809512",
       "identifiers": [
@@ -103,7 +103,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김동섭"
+        "lang:ko": "김동섭"
       },
       "id": "Q50809513",
       "identifiers": [
@@ -121,7 +121,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "정기현"
+        "lang:ko": "정기현"
       },
       "id": "Q50809515",
       "identifiers": [
@@ -136,7 +136,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "조원휘"
+        "lang:ko": "조원휘"
       },
       "id": "Q50809516",
       "identifiers": [
@@ -151,7 +151,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김경시"
+        "lang:ko": "김경시"
       },
       "id": "Q50809524",
       "identifiers": [
@@ -169,7 +169,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김인식"
+        "lang:ko": "김인식"
       },
       "id": "Q50809528",
       "identifiers": [
@@ -186,8 +186,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "대전광역시의회",
-        "lang:en_US": "Daejeon municipal council"
+        "lang:ko": "대전광역시의회",
+        "lang:en": "Daejeon municipal council"
       },
       "id": "Q16095510",
       "classification": "branch",
@@ -204,8 +204,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -218,8 +218,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -248,8 +248,8 @@
         "Q50615886"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Daejeon",
@@ -273,8 +273,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "동구제2선거구"
@@ -297,8 +297,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "중구제1선거구"
@@ -321,8 +321,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "서구제6선거구"
@@ -345,8 +345,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "대덕구제3선거구"
@@ -369,8 +369,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "유성구제1선거구"
@@ -393,8 +393,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "유성구제2선거구"
@@ -417,8 +417,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "서구제2선거구"
@@ -441,8 +441,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "대덕구제2선거구"
@@ -465,8 +465,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "동구제1선거구"
@@ -489,8 +489,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "중구제3선거구"
@@ -513,8 +513,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "동구제3선거구"
@@ -537,8 +537,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "서구제1선거구"
@@ -561,8 +561,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "서구제3선거구"
@@ -585,8 +585,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "대덕구제1선거구"
@@ -609,8 +609,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "유성구제3선거구"
@@ -633,8 +633,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "유성구제4선거구"
@@ -657,8 +657,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "서구제5선거구"
@@ -681,8 +681,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "서구제4선거구"
@@ -705,8 +705,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "중구제2선거구"
@@ -729,8 +729,8 @@
         "Q50559446"
       ],
       "type": {
-        "lang:ko_KR": "대전광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Daejeon"
+        "lang:ko": "대전광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
         "lang:ko_KR": "대전광역시 비례대표 선거구"
@@ -753,7 +753,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -772,13 +772,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -790,13 +790,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -808,13 +808,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -826,13 +826,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -844,13 +844,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -862,13 +862,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -880,13 +880,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -898,13 +898,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -916,13 +916,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -934,13 +934,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     },
     {
@@ -952,13 +952,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559446",
       "role": {
-        "lang:ko_KR": "대전광역시의원동정",
-        "lang:en_US": "Daejeon councilor"
+        "lang:ko": "대전광역시의원동정",
+        "lang:en": "Daejeon councilor"
       }
     }
   ]

--- a/legislative/Q16096697/Q50798199/popolo-m17n.json
+++ b/legislative/Q16096697/Q50798199/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "전봉민"
+        "lang:ko": "전봉민"
       },
       "id": "Q28699512",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "백종헌"
+        "lang:ko": "백종헌"
       },
       "id": "Q31180679",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이상갑"
+        "lang:ko": "이상갑"
       },
       "id": "Q50809768",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "오보근"
+        "lang:ko": "오보근"
       },
       "id": "Q50809769",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "강성태"
+        "lang:ko": "강성태"
       },
       "id": "Q50809772",
       "identifiers": [
@@ -80,7 +80,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "안재권"
+        "lang:ko": "안재권"
       },
       "id": "Q50809777",
       "identifiers": [
@@ -98,7 +98,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이해동"
+        "lang:ko": "이해동"
       },
       "id": "Q50809781",
       "identifiers": [
@@ -116,7 +116,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김진용"
+        "lang:ko": "김진용"
       },
       "id": "Q50809783",
       "identifiers": [
@@ -131,7 +131,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "윤종현"
+        "lang:ko": "윤종현"
       },
       "id": "Q50809786",
       "identifiers": [
@@ -149,7 +149,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박성명"
+        "lang:ko": "박성명"
       },
       "id": "Q50809797",
       "identifiers": [
@@ -164,7 +164,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김남희"
+        "lang:ko": "김남희"
       },
       "id": "Q50809868",
       "identifiers": [
@@ -181,8 +181,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "부산광역시의회",
-        "lang:en_US": "Busan municipal council"
+        "lang:ko": "부산광역시의회",
+        "lang:en": "Busan municipal council"
       },
       "id": "Q16096697",
       "classification": "branch",
@@ -199,8 +199,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -229,8 +229,8 @@
         "Q50265926"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Busan",
@@ -254,8 +254,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "동구제2선거구"
@@ -278,8 +278,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "동래구제3선거구"
@@ -302,8 +302,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "해운대구제4선거구"
@@ -326,8 +326,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "남구제1선거구"
@@ -350,8 +350,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "북구제3선거구"
@@ -374,8 +374,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "사하구제2선거구"
@@ -398,8 +398,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "금정구제2선거구"
@@ -422,8 +422,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "수영구제2선거구"
@@ -446,8 +446,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "연제구제2선거구"
@@ -470,8 +470,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "강서구제1선거구"
@@ -494,8 +494,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "동래구제1선거구"
@@ -518,8 +518,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "기장군제1선거구"
@@ -542,8 +542,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "동구제1선거구"
@@ -566,8 +566,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "사상구제1선거구"
@@ -590,8 +590,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "북구제4선거구"
@@ -614,8 +614,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "사하구제4선거구"
@@ -638,8 +638,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "영도구제1선거구"
@@ -662,8 +662,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "남구제2선거구"
@@ -686,8 +686,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "해운대구제2선거구"
@@ -710,8 +710,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "부산진구제4선거구"
@@ -734,8 +734,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "북구제1선거구"
@@ -758,8 +758,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "영도구제2선거구"
@@ -782,8 +782,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "기장군제2선거구"
@@ -806,8 +806,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "부산진구제1선거구"
@@ -830,8 +830,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "사하구제3선거구"
@@ -854,8 +854,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "서구제2선거구"
@@ -878,8 +878,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "남구제4선거구"
@@ -902,8 +902,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "부산진구제2선거구"
@@ -926,8 +926,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "중구선거구"
@@ -950,8 +950,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "남구제3선거구"
@@ -974,8 +974,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "수영구제1선거구"
@@ -998,8 +998,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "동래구제2선거구"
@@ -1022,8 +1022,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "서구제1선거구"
@@ -1046,8 +1046,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "해운대구제1선거구"
@@ -1070,8 +1070,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "강서구제2선거구"
@@ -1094,8 +1094,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "해운대구제3선거구"
@@ -1118,8 +1118,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "부산진구제3선거구"
@@ -1142,8 +1142,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "연제구제1선거구"
@@ -1166,8 +1166,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "사하구제1선거구"
@@ -1190,8 +1190,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "북구제2선거구"
@@ -1214,8 +1214,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "사상구제2선거구"
@@ -1238,8 +1238,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "금정구제1선거구"
@@ -1262,8 +1262,8 @@
         "Q50559275"
       ],
       "type": {
-        "lang:ko_KR": "부산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Busan"
+        "lang:ko": "부산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
         "lang:ko_KR": "부산광역시 비례대표 선거구"
@@ -1286,7 +1286,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -1305,13 +1305,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1323,13 +1323,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1341,13 +1341,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1359,13 +1359,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1377,13 +1377,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1395,13 +1395,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1413,13 +1413,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1431,13 +1431,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1449,13 +1449,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1467,13 +1467,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     },
     {
@@ -1485,13 +1485,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559275",
       "role": {
-        "lang:ko_KR": "부산광역시의원동정",
-        "lang:en_US": "Busan councilor"
+        "lang:ko": "부산광역시의원동정",
+        "lang:en": "Busan councilor"
       }
     }
   ]

--- a/legislative/Q16097908/Q50798215/popolo-m17n.json
+++ b/legislative/Q16097908/Q50798215/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "서금택"
+        "lang:ko": "서금택"
       },
       "id": "Q50809479",
       "identifiers": [
@@ -20,7 +20,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이태환"
+        "lang:ko": "이태환"
       },
       "id": "Q50809480",
       "identifiers": [
@@ -35,7 +35,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박영송"
+        "lang:ko": "박영송"
       },
       "id": "Q50809483",
       "identifiers": [
@@ -53,7 +53,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김원식"
+        "lang:ko": "김원식"
       },
       "id": "Q50809485",
       "identifiers": [
@@ -68,7 +68,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "장승업"
+        "lang:ko": "장승업"
       },
       "id": "Q50809487",
       "identifiers": [
@@ -83,7 +83,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김정봉"
+        "lang:ko": "김정봉"
       },
       "id": "Q50809488",
       "identifiers": [
@@ -98,7 +98,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "임상전"
+        "lang:ko": "임상전"
       },
       "id": "Q50809490",
       "identifiers": [
@@ -113,7 +113,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이충열"
+        "lang:ko": "이충열"
       },
       "id": "Q50809491",
       "identifiers": [
@@ -128,7 +128,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김선무"
+        "lang:ko": "김선무"
       },
       "id": "Q50809492",
       "identifiers": [
@@ -143,7 +143,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이경대"
+        "lang:ko": "이경대"
       },
       "id": "Q50809493",
       "identifiers": [
@@ -158,7 +158,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김복렬"
+        "lang:ko": "김복렬"
       },
       "id": "Q50809901",
       "identifiers": [
@@ -178,8 +178,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "세종특별자치시의회",
-        "lang:en_US": "Sejong City municipal council"
+        "lang:ko": "세종특별자치시의회",
+        "lang:en": "Sejong City municipal council"
       },
       "id": "Q16097908",
       "classification": "branch",
@@ -196,8 +196,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -210,8 +210,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -240,8 +240,8 @@
         "Q50274663"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 특별자치시",
-        "lang:en_US": "special autonomous city in South Korea"
+        "lang:ko": "대한민국의 특별자치시",
+        "lang:en": "special autonomous city in South Korea"
       },
       "name": {
         "lang:en_US": "Sejong Special Self-Governing City",
@@ -265,8 +265,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제13선거구"
@@ -289,8 +289,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제9선거구"
@@ -313,8 +313,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제4선거구"
@@ -337,8 +337,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제2선거구"
@@ -361,8 +361,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제11선거구"
@@ -385,8 +385,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제7선거구"
@@ -409,8 +409,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제5선거구"
@@ -433,8 +433,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제8선거구"
@@ -457,8 +457,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제6선거구"
@@ -481,8 +481,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제1선거구"
@@ -505,8 +505,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제3선거구"
@@ -529,8 +529,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제10선거구"
@@ -553,8 +553,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시제12선거구"
@@ -577,8 +577,8 @@
         "Q50559074"
       ],
       "type": {
-        "lang:ko_KR": "세종특별자치시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Sejong City"
+        "lang:ko": "세종특별자치시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시 비례대표 선거구"
@@ -601,7 +601,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -620,13 +620,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -638,13 +638,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -656,13 +656,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -674,13 +674,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -692,13 +692,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -709,13 +709,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -727,13 +727,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -745,13 +745,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -763,13 +763,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -781,13 +781,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     },
     {
@@ -799,13 +799,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559074",
       "role": {
-        "lang:ko_KR": "세종특별자치시의원동정",
-        "lang:en_US": "Sejong City councilor"
+        "lang:ko": "세종특별자치시의원동정",
+        "lang:en": "Sejong City councilor"
       }
     }
   ]

--- a/legislative/Q16099049/Q50798406/popolo-m17n.json
+++ b/legislative/Q16099049/Q50798406/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "허령"
+        "lang:ko": "허령"
       },
       "id": "Q27952773",
       "identifiers": [
@@ -20,7 +20,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "한동영"
+        "lang:ko": "한동영"
       },
       "id": "Q50809495",
       "identifiers": [
@@ -38,7 +38,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "윤시철"
+        "lang:ko": "윤시철"
       },
       "id": "Q50809496",
       "identifiers": [
@@ -56,7 +56,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "정치락"
+        "lang:ko": "정치락"
       },
       "id": "Q50809499",
       "identifiers": [
@@ -74,7 +74,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "문석주"
+        "lang:ko": "문석주"
       },
       "id": "Q50809500",
       "identifiers": [
@@ -92,7 +92,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "배영규"
+        "lang:ko": "배영규"
       },
       "id": "Q50809501",
       "identifiers": [
@@ -107,7 +107,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박학천"
+        "lang:ko": "박학천"
       },
       "id": "Q50809502",
       "identifiers": [
@@ -125,7 +125,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "천기옥"
+        "lang:ko": "천기옥"
       },
       "id": "Q50809503",
       "identifiers": [
@@ -143,7 +143,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "강대길"
+        "lang:ko": "강대길"
       },
       "id": "Q50809504",
       "identifiers": [
@@ -161,7 +161,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "변식용"
+        "lang:ko": "변식용"
       },
       "id": "Q50809506",
       "identifiers": [
@@ -176,7 +176,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "송해숙"
+        "lang:ko": "송해숙"
       },
       "id": "Q50809882",
       "identifiers": [
@@ -193,8 +193,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "울산광역시의회",
-        "lang:en_US": "Ulsan municipal council"
+        "lang:ko": "울산광역시의회",
+        "lang:en": "Ulsan municipal council"
       },
       "id": "Q16099049",
       "classification": "branch",
@@ -211,8 +211,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -241,8 +241,8 @@
         "Q50619818"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Ulsan",
@@ -266,8 +266,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "동구제2선거구"
@@ -290,8 +290,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "남구제1선거구"
@@ -314,8 +314,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "북구제1선거구"
@@ -338,8 +338,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "남구제5선거구"
@@ -362,8 +362,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "중구제1선거구"
@@ -386,8 +386,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "북구제3선거구"
@@ -410,8 +410,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "중구제3선거구"
@@ -434,8 +434,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "중구제4선거구"
@@ -458,8 +458,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "남구제6선거구"
@@ -482,8 +482,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "동구제3선거구"
@@ -506,8 +506,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "울주군제2선거구"
@@ -530,8 +530,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "남구제3선거구"
@@ -554,8 +554,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "동구제1선거구"
@@ -578,8 +578,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "울주군제3선거구"
@@ -602,8 +602,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "남구제4선거구"
@@ -626,8 +626,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "북구제2선거구"
@@ -650,8 +650,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "울주군제1선거구"
@@ -674,8 +674,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "남구제2선거구"
@@ -698,8 +698,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "중구제2선거구"
@@ -722,8 +722,8 @@
         "Q50558615"
       ],
       "type": {
-        "lang:ko_KR": "울산광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Ulsan"
+        "lang:ko": "울산광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
         "lang:ko_KR": "울산광역시 비례대표 선거구"
@@ -746,7 +746,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -765,13 +765,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -783,13 +783,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -801,13 +801,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -819,13 +819,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -837,13 +837,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -855,13 +855,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -873,13 +873,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -891,13 +891,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -909,13 +909,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -927,13 +927,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     },
     {
@@ -945,13 +945,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558615",
       "role": {
-        "lang:ko_KR": "울산광역시의원동정",
-        "lang:en_US": "Ulsan councilor"
+        "lang:ko": "울산광역시의원동정",
+        "lang:en": "Ulsan councilor"
       }
     }
   ]

--- a/legislative/Q16099448/Q50798182/popolo-m17n.json
+++ b/legislative/Q16099448/Q50798182/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "이도형"
+        "lang:ko": "이도형"
       },
       "id": "Q21710270",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김경선"
+        "lang:ko": "김경선"
       },
       "id": "Q50809554",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "안영수"
+        "lang:ko": "안영수"
       },
       "id": "Q50809561",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김진규"
+        "lang:ko": "김진규"
       },
       "id": "Q50809578",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "구재용"
+        "lang:ko": "구재용"
       },
       "id": "Q50809589",
       "identifiers": [
@@ -80,7 +80,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박승희"
+        "lang:ko": "박승희"
       },
       "id": "Q50809600",
       "identifiers": [
@@ -95,7 +95,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "조계자"
+        "lang:ko": "조계자"
       },
       "id": "Q50809611",
       "identifiers": [
@@ -110,7 +110,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이용범"
+        "lang:ko": "이용범"
       },
       "id": "Q50809616",
       "identifiers": [
@@ -128,7 +128,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이한구"
+        "lang:ko": "이한구"
       },
       "id": "Q50809623",
       "identifiers": [
@@ -146,7 +146,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박영애"
+        "lang:ko": "박영애"
       },
       "id": "Q50809875",
       "identifiers": [
@@ -161,7 +161,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "최석정"
+        "lang:ko": "최석정"
       },
       "id": "Q50810324",
       "identifiers": [
@@ -181,8 +181,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "인천광역시의회",
-        "lang:en_US": "Incheon municipal council"
+        "lang:ko": "인천광역시의회",
+        "lang:en": "Incheon municipal council"
       },
       "id": "Q16099448",
       "classification": "branch",
@@ -199,8 +199,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -213,8 +213,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -243,8 +243,8 @@
         "Q50617475"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Incheon",
@@ -268,8 +268,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "계양구제4선거구"
@@ -292,8 +292,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "부평구제4선거구"
@@ -316,8 +316,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "동구제2선거구"
@@ -340,8 +340,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "중구제1선거구"
@@ -364,8 +364,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "남동구제5선거구"
@@ -388,8 +388,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "부평구제2선거구"
@@ -412,8 +412,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "계양구제1선거구"
@@ -436,8 +436,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "남구제4선거구"
@@ -460,8 +460,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "부평구제5선거구"
@@ -484,8 +484,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "서구제3선거구"
@@ -508,8 +508,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "남동구제2선거구"
@@ -532,8 +532,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "연수구제2선거구"
@@ -556,8 +556,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "동구제1선거구"
@@ -580,8 +580,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "강화군선거구"
@@ -604,8 +604,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "남구제3선거구"
@@ -628,8 +628,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "연수구제1선거구"
@@ -652,8 +652,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "옹진군선거구"
@@ -676,8 +676,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "남동구제1선거구"
@@ -700,8 +700,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "남구제1선거구"
@@ -724,8 +724,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "남동구제3선거구"
@@ -748,8 +748,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "중구제2선거구"
@@ -772,8 +772,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "부평구제1선거구"
@@ -796,8 +796,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "부평구제3선거구"
@@ -820,8 +820,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "서구제2선거구"
@@ -844,8 +844,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "서구제4선거구"
@@ -868,8 +868,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "서구제1선거구"
@@ -892,8 +892,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "계양구제2선거구"
@@ -916,8 +916,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "남동구제4선거구"
@@ -940,8 +940,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "연수구제3선거구"
@@ -964,8 +964,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "계양구제3선거구"
@@ -988,8 +988,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "남구제2선거구"
@@ -1012,8 +1012,8 @@
         "Q50559472"
       ],
       "type": {
-        "lang:ko_KR": "인천광역시 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Incheon"
+        "lang:ko": "인천광역시 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
         "lang:ko_KR": "인천광역시 비례대표 선거구"
@@ -1036,7 +1036,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -1055,13 +1055,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1073,13 +1073,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1091,13 +1091,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1109,13 +1109,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1127,13 +1127,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1145,13 +1145,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1163,13 +1163,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1181,13 +1181,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1199,13 +1199,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1217,13 +1217,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     },
     {
@@ -1235,13 +1235,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559472",
       "role": {
-        "lang:ko_KR": "인천광역시의원동정",
-        "lang:en_US": "Incheon councilor"
+        "lang:ko": "인천광역시의원동정",
+        "lang:en": "Incheon councilor"
       }
     }
   ]

--- a/legislative/Q16099669/Q50798313/popolo-m17n.json
+++ b/legislative/Q16099669/Q50798313/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "임흥빈"
+        "lang:ko": "임흥빈"
       },
       "id": "Q50809323",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "정연선"
+        "lang:ko": "정연선"
       },
       "id": "Q50809324",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "임용수"
+        "lang:ko": "임용수"
       },
       "id": "Q50809330",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "노종석"
+        "lang:ko": "노종석"
       },
       "id": "Q50809333",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이동권"
+        "lang:ko": "이동권"
       },
       "id": "Q50809336",
       "identifiers": [
@@ -77,7 +77,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이장석"
+        "lang:ko": "이장석"
       },
       "id": "Q50809340",
       "identifiers": [
@@ -92,7 +92,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "양영복"
+        "lang:ko": "양영복"
       },
       "id": "Q50809341",
       "identifiers": [
@@ -107,7 +107,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "정영덕"
+        "lang:ko": "정영덕"
       },
       "id": "Q50809343",
       "identifiers": [
@@ -122,7 +122,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "우승희"
+        "lang:ko": "우승희"
       },
       "id": "Q50809344",
       "identifiers": [
@@ -137,7 +137,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김연일"
+        "lang:ko": "김연일"
       },
       "id": "Q50809346",
       "identifiers": [
@@ -152,7 +152,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "권애영"
+        "lang:ko": "권애영"
       },
       "id": "Q50809896",
       "identifiers": [
@@ -169,8 +169,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "전라남도의회",
-        "lang:en_US": "South Jeolla Province municipal council"
+        "lang:ko": "전라남도의회",
+        "lang:en": "South Jeolla Province municipal council"
       },
       "id": "Q16099669",
       "classification": "branch",
@@ -187,8 +187,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -201,8 +201,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -231,8 +231,8 @@
         "Q12615101"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Jeollanam-do",
@@ -256,8 +256,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "장흥군제1선거구"
@@ -280,8 +280,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "영광군제1선거구"
@@ -304,8 +304,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "광양시제2선거구"
@@ -328,8 +328,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "장성군제1선거구"
@@ -352,8 +352,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "목포시제1선거구"
@@ -376,8 +376,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "광양시제3선거구"
@@ -400,8 +400,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "화순군제1선거구"
@@ -424,8 +424,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "목포시제3선거구"
@@ -448,8 +448,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "나주시제2선거구"
@@ -472,8 +472,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "여수시제1선거구"
@@ -496,8 +496,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "장흥군제2선거구"
@@ -520,8 +520,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "영광군제2선거구"
@@ -544,8 +544,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "신안군제1선거구"
@@ -568,8 +568,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "목포시제5선거구"
@@ -592,8 +592,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "화순군제2선거구"
@@ -616,8 +616,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "여수시제2선거구"
@@ -640,8 +640,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "보성군제2선거구"
@@ -664,8 +664,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "함평군제1선거구"
@@ -688,8 +688,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "순천시제2선거구"
@@ -712,8 +712,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "순천시제3선거구"
@@ -736,8 +736,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "함평군제2선거구"
@@ -760,8 +760,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "곡성군선거구"
@@ -784,8 +784,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "목포시제4선거구"
@@ -808,8 +808,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "해남군제2선거구"
@@ -832,8 +832,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "고흥군제1선거구"
@@ -856,8 +856,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "여수시제4선거구"
@@ -880,8 +880,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "신안군제2선거구"
@@ -904,8 +904,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "무안군제2선거구"
@@ -928,8 +928,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "무안군제1선거구"
@@ -952,8 +952,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "여수시제6선거구"
@@ -976,8 +976,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "진도군선거구"
@@ -1000,8 +1000,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "완도군제1선거구"
@@ -1024,8 +1024,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "구례군선거구"
@@ -1048,8 +1048,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "여수시제5선거구"
@@ -1072,8 +1072,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "담양군제2선거구"
@@ -1096,8 +1096,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "해남군제1선거구"
@@ -1120,8 +1120,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "순천시제1선거구"
@@ -1144,8 +1144,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "순천시제5선거구"
@@ -1168,8 +1168,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "강진군제1선거구"
@@ -1192,8 +1192,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "담양군제1선거구"
@@ -1216,8 +1216,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "영암군제1선거구"
@@ -1240,8 +1240,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "나주시제1선거구"
@@ -1264,8 +1264,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "여수시제3선거구"
@@ -1288,8 +1288,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "강진군제2선거구"
@@ -1312,8 +1312,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "목포시제2선거구"
@@ -1336,8 +1336,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "보성군제1선거구"
@@ -1360,8 +1360,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "영암군제2선거구"
@@ -1384,8 +1384,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "장성군제2선거구"
@@ -1408,8 +1408,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "고흥군제2선거구"
@@ -1432,8 +1432,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "광양시제1선거구"
@@ -1456,8 +1456,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "순천시제4선거구"
@@ -1480,8 +1480,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "완도군제2선거구"
@@ -1504,8 +1504,8 @@
         "Q50559426"
       ],
       "type": {
-        "lang:ko_KR": "전라남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Jeolla Province"
+        "lang:ko": "전라남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전라남도 비례대표 선거구"
@@ -1528,7 +1528,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -1547,13 +1547,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1565,13 +1565,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1583,13 +1583,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1601,13 +1601,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1619,13 +1619,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1637,13 +1637,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1654,13 +1654,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1672,13 +1672,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1690,13 +1690,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1708,13 +1708,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     },
     {
@@ -1726,13 +1726,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559426",
       "role": {
-        "lang:ko_KR": "전라남도의원동정",
-        "lang:en_US": "South Jeolla Province councilor"
+        "lang:ko": "전라남도의원동정",
+        "lang:en": "South Jeolla Province councilor"
       }
     }
   ]

--- a/legislative/Q16100275/Q50798329/popolo-m17n.json
+++ b/legislative/Q16100275/Q50798329/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "김용필"
+        "lang:ko": "김용필"
       },
       "id": "Q50809367",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김기영"
+        "lang:ko": "김기영"
       },
       "id": "Q50809371",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김홍열"
+        "lang:ko": "김홍열"
       },
       "id": "Q50809376",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "오배근"
+        "lang:ko": "오배근"
       },
       "id": "Q50809377",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이종화"
+        "lang:ko": "이종화"
       },
       "id": "Q50809382",
       "identifiers": [
@@ -77,7 +77,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "서형달"
+        "lang:ko": "서형달"
       },
       "id": "Q50809384",
       "identifiers": [
@@ -92,7 +92,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "조이환"
+        "lang:ko": "조이환"
       },
       "id": "Q50809385",
       "identifiers": [
@@ -107,7 +107,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "유찬종"
+        "lang:ko": "유찬종"
       },
       "id": "Q50809387",
       "identifiers": [
@@ -122,7 +122,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "강용일"
+        "lang:ko": "강용일"
       },
       "id": "Q50809388",
       "identifiers": [
@@ -137,7 +137,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이용호"
+        "lang:ko": "이용호"
       },
       "id": "Q50809390",
       "identifiers": [
@@ -152,7 +152,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "정정희"
+        "lang:ko": "정정희"
       },
       "id": "Q50809893",
       "identifiers": [
@@ -169,8 +169,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "충청남도의회",
-        "lang:en_US": "South Chungcheong Province municipal council"
+        "lang:ko": "충청남도의회",
+        "lang:en": "South Chungcheong Province municipal council"
       },
       "id": "Q16100275",
       "classification": "branch",
@@ -187,8 +187,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -201,8 +201,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -231,8 +231,8 @@
         "Q50619614"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Chungcheongnam-do",
@@ -256,8 +256,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청양군선거구"
@@ -280,8 +280,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "천안시제2선거구"
@@ -304,8 +304,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "천안시제5선거구"
@@ -328,8 +328,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "서산시제2선거구"
@@ -352,8 +352,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "천안시제4선거구"
@@ -376,8 +376,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "서천군제1선거구"
@@ -400,8 +400,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "천안시제6선거구"
@@ -424,8 +424,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "예산군제2선거구"
@@ -448,8 +448,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "계룡시선거구"
@@ -472,8 +472,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "부여군제1선거구"
@@ -496,8 +496,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "금산군제2선거구"
@@ -520,8 +520,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "천안시제7선거구"
@@ -544,8 +544,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "보령시제2선거구"
@@ -568,8 +568,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "공주시제2선거구"
@@ -592,8 +592,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "부여군제2선거구"
@@ -616,8 +616,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "천안시제8선거구"
@@ -640,8 +640,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "태안군제1선거구"
@@ -664,8 +664,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "공주시제1선거구"
@@ -688,8 +688,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "아산시제3선거구"
@@ -712,8 +712,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "아산시제4선거구"
@@ -736,8 +736,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "홍성군제1선거구"
@@ -760,8 +760,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "보령시제1선거구"
@@ -784,8 +784,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "천안시제1선거구"
@@ -808,8 +808,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "아산시제1선거구"
@@ -832,8 +832,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "논산시제1선거구"
@@ -856,8 +856,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "당진시제1선거구"
@@ -880,8 +880,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "천안시제3선거구"
@@ -904,8 +904,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "예산군제1선거구"
@@ -928,8 +928,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "당진시제2선거구"
@@ -952,8 +952,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "서천군제2선거구"
@@ -976,8 +976,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "홍성군제2선거구"
@@ -1000,8 +1000,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "아산시제2선거구"
@@ -1024,8 +1024,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "태안군제2선거구"
@@ -1048,8 +1048,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "서산시제1선거구"
@@ -1072,8 +1072,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "금산군제1선거구"
@@ -1096,8 +1096,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "논산시제2선거구"
@@ -1120,8 +1120,8 @@
         "Q50558073"
       ],
       "type": {
-        "lang:ko_KR": "충청남도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of South Chungcheong Province"
+        "lang:ko": "충청남도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "충청남도 비례대표 선거구"
@@ -1144,7 +1144,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -1163,13 +1163,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1181,13 +1181,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1199,13 +1199,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1217,13 +1217,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1235,13 +1235,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1253,13 +1253,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1271,13 +1271,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1289,13 +1289,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1307,13 +1307,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1325,13 +1325,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     },
     {
@@ -1343,13 +1343,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50558073",
       "role": {
-        "lang:ko_KR": "충청남도의원동정",
-        "lang:en_US": "South Chungcheong Province councilor"
+        "lang:ko": "충청남도의원동정",
+        "lang:en": "South Chungcheong Province councilor"
       }
     }
   ]

--- a/legislative/Q16100304/Q50798260/popolo-m17n.json
+++ b/legislative/Q16100304/Q50798260/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "정영수"
+        "lang:ko": "정영수"
       },
       "id": "Q16907607",
       "identifiers": [
@@ -17,8 +17,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박병진",
-        "lang:en_US": "B. J. Pak"
+        "lang:ko": "박병진",
+        "lang:en": "B. J. Pak"
       },
       "id": "Q28840361",
       "identifiers": [
@@ -33,7 +33,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "윤은희"
+        "lang:ko": "윤은희"
       },
       "id": "Q50809217",
       "identifiers": [
@@ -48,7 +48,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김봉회"
+        "lang:ko": "김봉회"
       },
       "id": "Q50809399",
       "identifiers": [
@@ -63,7 +63,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "임회무"
+        "lang:ko": "임회무"
       },
       "id": "Q50809401",
       "identifiers": [
@@ -78,7 +78,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이양섭"
+        "lang:ko": "이양섭"
       },
       "id": "Q50809404",
       "identifiers": [
@@ -93,7 +93,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "최병윤"
+        "lang:ko": "최병윤"
       },
       "id": "Q50809405",
       "identifiers": [
@@ -108,7 +108,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이광진"
+        "lang:ko": "이광진"
       },
       "id": "Q50809422",
       "identifiers": [
@@ -123,7 +123,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박한범"
+        "lang:ko": "박한범"
       },
       "id": "Q50809424",
       "identifiers": [
@@ -138,7 +138,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "황규철"
+        "lang:ko": "황규철"
       },
       "id": "Q50809426",
       "identifiers": [
@@ -153,7 +153,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김인수"
+        "lang:ko": "김인수"
       },
       "id": "Q50809435",
       "identifiers": [
@@ -170,8 +170,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "충청북도의회",
-        "lang:en_US": "North Chungcheong Province municipal council"
+        "lang:ko": "충청북도의회",
+        "lang:en": "North Chungcheong Province municipal council"
       },
       "id": "Q16100304",
       "classification": "branch",
@@ -188,8 +188,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -202,8 +202,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -232,8 +232,8 @@
         "Q50619326"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Chungcheongbuk-do",
@@ -257,8 +257,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제2선거구"
@@ -281,8 +281,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "옥천군제1선거구"
@@ -305,8 +305,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "괴산군선거구"
@@ -329,8 +329,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제1선거구"
@@ -353,8 +353,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "증평군선거구"
@@ -377,8 +377,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "충주시제2선거구"
@@ -401,8 +401,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "충주시제1선거구"
@@ -425,8 +425,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "진천군제2선거구"
@@ -449,8 +449,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제9선거구"
@@ -473,8 +473,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "영동군제2선거구"
@@ -497,8 +497,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제3선거구"
@@ -521,8 +521,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "진천군제1선거구"
@@ -545,8 +545,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "단양군선거구"
@@ -569,8 +569,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "음성군제1선거구"
@@ -593,8 +593,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제10선거구"
@@ -617,8 +617,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제6선거구"
@@ -641,8 +641,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제8선거구"
@@ -665,8 +665,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제11선거구"
@@ -689,8 +689,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제4선거구"
@@ -713,8 +713,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "제천시제2선거구"
@@ -737,8 +737,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "음성군제2선거구"
@@ -761,8 +761,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "영동군제1선거구"
@@ -785,8 +785,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "충주시제3선거구"
@@ -809,8 +809,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제7선거구"
@@ -833,8 +833,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "옥천군제2선거구"
@@ -857,8 +857,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "제천시제1선거구"
@@ -881,8 +881,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "보은군선거구"
@@ -905,8 +905,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "청주시제5선거구"
@@ -929,8 +929,8 @@
         "Q50559246"
       ],
       "type": {
-        "lang:ko_KR": "충청북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Chungcheong Province"
+        "lang:ko": "충청북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
         "lang:ko_KR": "충청북도 비례대표 선거구"
@@ -953,7 +953,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -972,13 +972,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -990,13 +990,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -1008,13 +1008,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -1026,13 +1026,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -1044,13 +1044,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -1062,13 +1062,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -1080,13 +1080,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -1098,13 +1098,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -1116,13 +1116,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -1134,13 +1134,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     },
     {
@@ -1152,13 +1152,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559246",
       "role": {
-        "lang:ko_KR": "충청북도의원동정",
-        "lang:en_US": "North Chungcheong Province councilor"
+        "lang:ko": "충청북도의원동정",
+        "lang:en": "North Chungcheong Province councilor"
       }
     }
   ]

--- a/legislative/Q16100817/Q50798465/popolo-m17n.json
+++ b/legislative/Q16100817/Q50798465/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "김천문"
+        "lang:ko": "김천문"
       },
       "id": "Q16095030",
       "identifiers": [
@@ -17,8 +17,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "위성곤",
-        "lang:en_US": "Wi Seong-gon"
+        "lang:ko": "위성곤",
+        "lang:en": "Wi Seong-gon"
       },
       "id": "Q24000515",
       "identifiers": [
@@ -31,22 +31,7 @@
         {
           "note": "facebook",
           "url": "https://www.facebook.com/wisg1128"
-        }
-      ]
-    },
-    {
-      "name": {
-        "lang:ko_KR": "위성곤",
-        "lang:en_US": "Wi Seong-gon"
-      },
-      "id": "Q24000515",
-      "identifiers": [
-        {
-          "scheme": "wikidata",
-          "identifier": "Q24000515"
-        }
-      ],
-      "links": [
+        },
         {
           "note": "facebook",
           "url": "https://www.facebook.com/seogwipowsg"
@@ -55,7 +40,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "허창옥"
+        "lang:ko": "허창옥"
       },
       "id": "Q28700267",
       "identifiers": [
@@ -73,7 +58,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김용범"
+        "lang:ko": "김용범"
       },
       "id": "Q50809255",
       "identifiers": [
@@ -88,7 +73,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이경용"
+        "lang:ko": "이경용"
       },
       "id": "Q50809258",
       "identifiers": [
@@ -106,7 +91,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "현정화"
+        "lang:ko": "현정화"
       },
       "id": "Q50809261",
       "identifiers": [
@@ -124,7 +109,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "현우범"
+        "lang:ko": "현우범"
       },
       "id": "Q50809275",
       "identifiers": [
@@ -139,7 +124,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "고용호"
+        "lang:ko": "고용호"
       },
       "id": "Q50809277",
       "identifiers": [
@@ -157,7 +142,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "구성지"
+        "lang:ko": "구성지"
       },
       "id": "Q50809278",
       "identifiers": [
@@ -175,7 +160,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "강연호"
+        "lang:ko": "강연호"
       },
       "id": "Q50809280",
       "identifiers": [
@@ -190,7 +175,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "유진의"
+        "lang:ko": "유진의"
       },
       "id": "Q50809900",
       "identifiers": [
@@ -210,8 +195,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "제주특별자치도의회",
-        "lang:en_US": "Jeju municipal council"
+        "lang:ko": "제주특별자치도의회",
+        "lang:en": "Jeju municipal council"
       },
       "id": "Q16100817",
       "classification": "branch",
@@ -228,8 +213,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -242,8 +227,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -272,8 +257,8 @@
         "Q50275066"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 특별자치도",
-        "lang:en_US": "Special Self-governing Province of South Korea"
+        "lang:ko": "대한민국의 특별자치도",
+        "lang:en": "Special Self-governing Province of South Korea"
       },
       "name": {
         "lang:en_US": "Jeju Special Self-Governing Province",
@@ -297,8 +282,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제13선거구"
@@ -321,8 +306,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제19선거구"
@@ -345,8 +330,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제26선거구"
@@ -369,8 +354,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제1선거구"
@@ -393,8 +378,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제28선거구"
@@ -417,8 +402,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제20선거구"
@@ -441,8 +426,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제6선거구"
@@ -465,8 +450,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제21선거구"
@@ -489,8 +474,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제9선거구"
@@ -513,8 +498,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제10선거구"
@@ -537,8 +522,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제29선거구"
@@ -561,8 +546,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제12선거구"
@@ -585,8 +570,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제18선거구"
@@ -609,8 +594,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제23선거구"
@@ -633,8 +618,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제5선거구"
@@ -657,8 +642,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제15선거구"
@@ -681,8 +666,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제2선거구"
@@ -705,8 +690,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제8선거구"
@@ -729,8 +714,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제14선거구"
@@ -753,8 +738,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제17선거구"
@@ -777,8 +762,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제22선거구"
@@ -801,8 +786,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제24선거구"
@@ -825,8 +810,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제3선거구"
@@ -849,8 +834,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제16선거구"
@@ -873,8 +858,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제7선거구"
@@ -897,8 +882,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제27선거구"
@@ -921,8 +906,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제4선거구"
@@ -945,8 +930,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제25선거구"
@@ -969,8 +954,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도제11선거구"
@@ -993,8 +978,8 @@
         "Q50559384"
       ],
       "type": {
-        "lang:ko_KR": "제주특별자치도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Jeju"
+        "lang:ko": "제주특별자치도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도 비례대표 선거구"
@@ -1017,7 +1002,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -1036,13 +1021,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1054,13 +1039,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1071,13 +1056,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1089,13 +1074,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1106,13 +1091,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1124,13 +1109,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1142,13 +1127,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1160,13 +1145,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1178,13 +1163,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1196,13 +1181,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     },
     {
@@ -1214,13 +1199,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559384",
       "role": {
-        "lang:ko_KR": "제주특별자치도의원동정",
-        "lang:en_US": "Jeju councilor"
+        "lang:ko": "제주특별자치도의원동정",
+        "lang:en": "Jeju councilor"
       }
     }
   ]

--- a/legislative/Q20779829/Q50798444/popolo-m17n.json
+++ b/legislative/Q20779829/Q50798444/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "오구환"
+        "lang:ko": "오구환"
       },
       "id": "Q31177041",
       "identifiers": [
@@ -20,7 +20,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김승남"
+        "lang:ko": "김승남"
       },
       "id": "Q50809465",
       "identifiers": [
@@ -35,7 +35,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "윤광신"
+        "lang:ko": "윤광신"
       },
       "id": "Q50809468",
       "identifiers": [
@@ -53,7 +53,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김광철"
+        "lang:ko": "김광철"
       },
       "id": "Q50809470",
       "identifiers": [
@@ -71,7 +71,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "최춘식"
+        "lang:ko": "최춘식"
       },
       "id": "Q50809472",
       "identifiers": [
@@ -89,7 +89,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "윤영창"
+        "lang:ko": "윤영창"
       },
       "id": "Q50809473",
       "identifiers": [
@@ -104,7 +104,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박광서"
+        "lang:ko": "박광서"
       },
       "id": "Q50809474",
       "identifiers": [
@@ -119,7 +119,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "장동길"
+        "lang:ko": "장동길"
       },
       "id": "Q50809475",
       "identifiers": [
@@ -134,7 +134,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "조승현"
+        "lang:ko": "조승현"
       },
       "id": "Q50809476",
       "identifiers": [
@@ -149,7 +149,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김준현"
+        "lang:ko": "김준현"
       },
       "id": "Q50809478",
       "identifiers": [
@@ -164,7 +164,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "민병숙"
+        "lang:ko": "민병숙"
       },
       "id": "Q50809885",
       "identifiers": [
@@ -184,8 +184,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "경기도의회",
-        "lang:en_US": "Gyeonggi Province municipal council"
+        "lang:ko": "경기도의회",
+        "lang:en": "Gyeonggi Province municipal council"
       },
       "id": "Q20779829",
       "classification": "branch",
@@ -202,8 +202,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -216,8 +216,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -246,8 +246,8 @@
         "Q12583545"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gyeonggi-do",
@@ -271,8 +271,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "용인시제8선거구"
@@ -295,8 +295,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "고양시제4선거구"
@@ -319,8 +319,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "용인시제2선거구"
@@ -343,8 +343,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "부천시제1선거구"
@@ -367,8 +367,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "화성시제3선거구"
@@ -391,8 +391,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "수원시제3선거구"
@@ -415,8 +415,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "군포시제1선거구"
@@ -439,8 +439,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "성남시제1선거구"
@@ -463,8 +463,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안산시제6선거구"
@@ -487,8 +487,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "남양주시제2선거구"
@@ -511,8 +511,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "의정부시제2선거구"
@@ -535,8 +535,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "성남시제5선거구"
@@ -559,8 +559,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "시흥시제4선거구"
@@ -583,8 +583,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "광주시제1선거구"
@@ -607,8 +607,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "평택시제3선거구"
@@ -631,8 +631,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "남양주시제3선거구"
@@ -655,8 +655,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "파주시제2선거구"
@@ -679,8 +679,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안양시제6선거구"
@@ -703,8 +703,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안양시제4선거구"
@@ -727,8 +727,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "가평군선거구"
@@ -751,8 +751,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "광명시제1선거구"
@@ -775,8 +775,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "용인시제4선거구"
@@ -799,8 +799,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "성남시제8선거구"
@@ -823,8 +823,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안양시제5선거구"
@@ -847,8 +847,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "화성시제4선거구"
@@ -871,8 +871,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "부천시제5선거구"
@@ -895,8 +895,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안양시제2선거구"
@@ -919,8 +919,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "고양시제6선거구"
@@ -943,8 +943,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "이천시제2선거구"
@@ -967,8 +967,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "성남시제6선거구"
@@ -991,8 +991,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "고양시제5선거구"
@@ -1015,8 +1015,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "성남시제7선거구"
@@ -1039,8 +1039,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "수원시제5선거구"
@@ -1063,8 +1063,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "김포시제2선거구"
@@ -1087,8 +1087,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "여주시제1선거구"
@@ -1111,8 +1111,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "성남시제4선거구"
@@ -1135,8 +1135,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "용인시제7선거구"
@@ -1159,8 +1159,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "파주시제4선거구"
@@ -1183,8 +1183,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "김포시제3선거구"
@@ -1207,8 +1207,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "용인시제6선거구"
@@ -1231,8 +1231,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안성시제1선거구"
@@ -1255,8 +1255,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "부천시제8선거구"
@@ -1279,8 +1279,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "용인시제1선거구"
@@ -1303,8 +1303,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "용인시제5선거구"
@@ -1327,8 +1327,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "성남시제2선거구"
@@ -1351,8 +1351,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "과천시선거구"
@@ -1375,8 +1375,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "고양시제2선거구"
@@ -1399,8 +1399,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "양평군제2선거구"
@@ -1423,8 +1423,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안산시제7선거구"
@@ -1447,8 +1447,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "고양시제8선거구"
@@ -1471,8 +1471,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "파주시제1선거구"
@@ -1495,8 +1495,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "광주시제2선거구"
@@ -1519,8 +1519,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안양시제3선거구"
@@ -1543,8 +1543,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "포천시제1선거구"
@@ -1567,8 +1567,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "남양주시제4선거구"
@@ -1591,8 +1591,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "오산시제2선거구"
@@ -1615,8 +1615,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "남양주시제1선거구"
@@ -1639,8 +1639,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "포천시제2선거구"
@@ -1663,8 +1663,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "수원시제1선거구"
@@ -1687,8 +1687,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "구리시제1선거구"
@@ -1711,8 +1711,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안산시제1선거구"
@@ -1735,8 +1735,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "수원시제2선거구"
@@ -1759,8 +1759,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "화성시제1선거구"
@@ -1783,8 +1783,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "의정부시제1선거구"
@@ -1807,8 +1807,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "부천시제3선거구"
@@ -1831,8 +1831,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "연천군선거구"
@@ -1855,8 +1855,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "부천시제7선거구"
@@ -1879,8 +1879,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안산시제8선거구"
@@ -1903,8 +1903,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "파주시제3선거구"
@@ -1927,8 +1927,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "구리시제2선거구"
@@ -1951,8 +1951,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "하남시제1선거구"
@@ -1975,8 +1975,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "오산시제1선거구"
@@ -1999,8 +1999,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "고양시제7선거구"
@@ -2023,8 +2023,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안성시제2선거구"
@@ -2047,8 +2047,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "동두천시제2선거구"
@@ -2071,8 +2071,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안산시제5선거구"
@@ -2095,8 +2095,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "하남시제2선거구"
@@ -2119,8 +2119,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "성남시제3선거구"
@@ -2143,8 +2143,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "고양시제1선거구"
@@ -2167,8 +2167,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "수원시제8선거구"
@@ -2191,8 +2191,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "수원시제9선거구"
@@ -2215,8 +2215,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "의왕시제1선거구"
@@ -2239,8 +2239,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "양평군제1선거구"
@@ -2263,8 +2263,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "시흥시제2선거구"
@@ -2287,8 +2287,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "광명시제2선거구"
@@ -2311,8 +2311,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "화성시제2선거구"
@@ -2335,8 +2335,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "양주시제2선거구"
@@ -2359,8 +2359,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "시흥시제3선거구"
@@ -2383,8 +2383,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "평택시제2선거구"
@@ -2407,8 +2407,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "광명시제4선거구"
@@ -2431,8 +2431,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "평택시제4선거구"
@@ -2455,8 +2455,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "수원시제6선거구"
@@ -2479,8 +2479,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "평택시제1선거구"
@@ -2503,8 +2503,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "김포시제1선거구"
@@ -2527,8 +2527,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "동두천시제1선거구"
@@ -2551,8 +2551,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "수원시제7선거구"
@@ -2575,8 +2575,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "부천시제2선거구"
@@ -2599,8 +2599,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "이천시제1선거구"
@@ -2623,8 +2623,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "의정부시제4선거구"
@@ -2647,8 +2647,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안산시제2선거구"
@@ -2671,8 +2671,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "용인시제3선거구"
@@ -2695,8 +2695,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "광명시제3선거구"
@@ -2719,8 +2719,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "부천시제4선거구"
@@ -2743,8 +2743,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "고양시제3선거구"
@@ -2767,8 +2767,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "시흥시제1선거구"
@@ -2791,8 +2791,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "양주시제1선거구"
@@ -2815,8 +2815,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "의왕시제2선거구"
@@ -2839,8 +2839,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안양시제1선거구"
@@ -2863,8 +2863,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "군포시제2선거구"
@@ -2887,8 +2887,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "남양주시제5선거구"
@@ -2911,8 +2911,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "수원시제4선거구"
@@ -2935,8 +2935,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "부천시제6선거구"
@@ -2959,8 +2959,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "여주시제2선거구"
@@ -2983,8 +2983,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안산시제4선거구"
@@ -3007,8 +3007,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "안산시제3선거구"
@@ -3031,8 +3031,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "의정부시제3선거구"
@@ -3055,8 +3055,8 @@
         "Q50559168"
       ],
       "type": {
-        "lang:ko_KR": "경기도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of Gyeonggi Province"
+        "lang:ko": "경기도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
         "lang:ko_KR": "경기도 비례대표 선거구"
@@ -3079,7 +3079,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -3098,13 +3098,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3116,13 +3116,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3134,13 +3134,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3152,13 +3152,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3170,13 +3170,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3188,13 +3188,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3206,13 +3206,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3224,13 +3224,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3242,13 +3242,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3260,13 +3260,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     },
     {
@@ -3278,13 +3278,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559168",
       "role": {
-        "lang:ko_KR": "경기도의원동정",
-        "lang:en_US": "Gyeonggi Province councilor"
+        "lang:ko": "경기도의원동정",
+        "lang:en": "Gyeonggi Province councilor"
       }
     }
   ]

--- a/legislative/Q21060148/Q50798429/popolo-m17n.json
+++ b/legislative/Q21060148/Q50798429/popolo-m17n.json
@@ -2,7 +2,7 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "최훈열"
+        "lang:ko": "최훈열"
       },
       "id": "Q50809209",
       "identifiers": [
@@ -17,7 +17,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "조병서"
+        "lang:ko": "조병서"
       },
       "id": "Q50809347",
       "identifiers": [
@@ -32,7 +32,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이호근"
+        "lang:ko": "이호근"
       },
       "id": "Q50809350",
       "identifiers": [
@@ -47,7 +47,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "장명식"
+        "lang:ko": "장명식"
       },
       "id": "Q50809352",
       "identifiers": [
@@ -62,7 +62,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "최영일"
+        "lang:ko": "최영일"
       },
       "id": "Q50809355",
       "identifiers": [
@@ -77,7 +77,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "한완수"
+        "lang:ko": "한완수"
       },
       "id": "Q50809357",
       "identifiers": [
@@ -92,7 +92,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "양성빈"
+        "lang:ko": "양성빈"
       },
       "id": "Q50809358",
       "identifiers": [
@@ -107,7 +107,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "백경태"
+        "lang:ko": "백경태"
       },
       "id": "Q50809361",
       "identifiers": [
@@ -122,7 +122,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김현철"
+        "lang:ko": "김현철"
       },
       "id": "Q50809365",
       "identifiers": [
@@ -137,7 +137,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "송지용"
+        "lang:ko": "송지용"
       },
       "id": "Q50809366",
       "identifiers": [
@@ -152,7 +152,7 @@
     },
     {
       "name": {
-        "lang:ko_KR": "허남주"
+        "lang:ko": "허남주"
       },
       "id": "Q50809894",
       "identifiers": [
@@ -169,8 +169,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "전라북도의회",
-        "lang:en_US": "North Jeolla Province municipal council"
+        "lang:ko": "전라북도의회",
+        "lang:en": "North Jeolla Province municipal council"
       },
       "id": "Q21060148",
       "classification": "branch",
@@ -187,8 +187,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -201,8 +201,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -231,8 +231,8 @@
         "Q50619493"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Jeollabuk-do",
@@ -256,8 +256,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전주시제1선거구"
@@ -280,8 +280,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "순창군선거구"
@@ -304,8 +304,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "무주군선거구"
@@ -328,8 +328,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "완주군제2선거구"
@@ -352,8 +352,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "김제시제2선거구"
@@ -376,8 +376,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "정읍시제2선거구"
@@ -400,8 +400,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "남원시제2선거구"
@@ -424,8 +424,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전주시제7선거구"
@@ -448,8 +448,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "군산시제3선거구"
@@ -472,8 +472,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전주시제9선거구"
@@ -496,8 +496,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전주시제4선거구"
@@ -520,8 +520,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "익산시제4선거구"
@@ -544,8 +544,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "완주군제1선거구"
@@ -568,8 +568,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "군산시제4선거구"
@@ -592,8 +592,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전주시제8선거구"
@@ -616,8 +616,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전주시제6선거구"
@@ -640,8 +640,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전주시제2선거구"
@@ -664,8 +664,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "장수군선거구"
@@ -688,8 +688,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "익산시제1선거구"
@@ -712,8 +712,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "김제시제1선거구"
@@ -736,8 +736,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "부안군제1선거구"
@@ -760,8 +760,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "정읍시제1선거구"
@@ -784,8 +784,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "진안군선거구"
@@ -808,8 +808,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "고창군제1선거구"
@@ -832,8 +832,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "임실군선거구"
@@ -856,8 +856,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "부안군제2선거구"
@@ -880,8 +880,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전주시제3선거구"
@@ -904,8 +904,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "군산시제1선거구"
@@ -928,8 +928,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "남원시제1선거구"
@@ -952,8 +952,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "익산시제3선거구"
@@ -976,8 +976,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전주시제5선거구"
@@ -1000,8 +1000,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "익산시제2선거구"
@@ -1024,8 +1024,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "군산시제2선거구"
@@ -1048,8 +1048,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "고창군제2선거구"
@@ -1072,8 +1072,8 @@
         "Q50559371"
       ],
       "type": {
-        "lang:ko_KR": "전라북도 의원동정 선거구",
-        "lang:en_US": "FLACS Council Constituency of North Jeolla Province"
+        "lang:ko": "전라북도 의원동정 선거구",
+        "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
         "lang:ko_KR": "전라북도 비례대표 선거구"
@@ -1096,7 +1096,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -1115,13 +1115,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1133,13 +1133,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1151,13 +1151,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1169,13 +1169,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1187,13 +1187,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1204,13 +1204,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1222,13 +1222,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1240,13 +1240,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1257,13 +1257,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1275,13 +1275,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     },
     {
@@ -1293,13 +1293,13 @@
       "start_date": "2014-07-01",
       "role_superclass_code": "Q708492",
       "role_superclass": {
-        "lang:ko_KR": "참사관",
-        "lang:en_US": "councillor"
+        "lang:ko": "참사관",
+        "lang:en": "councillor"
       },
       "role_code": "Q50559371",
       "role": {
-        "lang:ko_KR": "전라북도의원동정",
-        "lang:en_US": "North Jeolla Province councilor"
+        "lang:ko": "전라북도의원동정",
+        "lang:en": "North Jeolla Province councilor"
       }
     }
   ]

--- a/legislative/Q494162/Q22971549/popolo-m17n.json
+++ b/legislative/Q494162/Q22971549/popolo-m17n.json
@@ -2,8 +2,8 @@
   "persons": [
     {
       "name": {
-        "lang:ko_KR": "강창일",
-        "lang:en_US": "Kang Chang-il"
+        "lang:ko": "강창일",
+        "lang:en": "Kang Chang-il"
       },
       "id": "Q10855142",
       "identifiers": [
@@ -21,8 +21,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "심상정",
-        "lang:en_US": "Sim Sang-jung"
+        "lang:ko": "심상정",
+        "lang:en": "Sim Sang-jung"
       },
       "id": "Q11255427",
       "identifiers": [
@@ -40,8 +40,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "정세균",
-        "lang:en_US": "Chung Sye-kyun"
+        "lang:ko": "정세균",
+        "lang:en": "Chung Sye-kyun"
       },
       "id": "Q11270093",
       "identifiers": [
@@ -59,8 +59,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "박맹우",
-        "lang:en_US": "Bak Maeng-woo"
+        "lang:ko": "박맹우",
+        "lang:en": "Bak Maeng-woo"
       },
       "id": "Q11986047",
       "identifiers": [
@@ -75,8 +75,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "김세연",
-        "lang:en_US": "Kim Se-yeon"
+        "lang:ko": "김세연",
+        "lang:en": "Kim Se-yeon"
       },
       "id": "Q16080285",
       "identifiers": [
@@ -94,8 +94,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이수혁",
-        "lang:en_US": "Lee Soo-hyuck"
+        "lang:ko": "이수혁",
+        "lang:en": "Lee Soo-hyuck"
       },
       "id": "Q22974711",
       "identifiers": [
@@ -110,8 +110,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "심기준",
-        "lang:en_US": "Shim Ki-joon"
+        "lang:ko": "심기준",
+        "lang:en": "Shim Ki-joon"
       },
       "id": "Q30093075",
       "identifiers": [
@@ -126,8 +126,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "이해찬",
-        "lang:en_US": "Lee Hae Chan"
+        "lang:ko": "이해찬",
+        "lang:en": "Lee Hae Chan"
       },
       "id": "Q319920",
       "identifiers": [
@@ -147,8 +147,8 @@
   "organizations": [
     {
       "name": {
-        "lang:ko_KR": "대한민국 국회",
-        "lang:en_US": "National Assembly"
+        "lang:ko": "대한민국 국회",
+        "lang:en": "National Assembly"
       },
       "id": "Q494162",
       "classification": "branch",
@@ -165,8 +165,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "더불어민주당",
-        "lang:en_US": "Democratic Party of Korea"
+        "lang:ko": "더불어민주당",
+        "lang:en": "Democratic Party of Korea"
       },
       "id": "Q15978686",
       "classification": "party",
@@ -179,8 +179,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "자유한국당",
-        "lang:en_US": "Liberty Korea Party"
+        "lang:ko": "자유한국당",
+        "lang:en": "Liberty Korea Party"
       },
       "id": "Q20916",
       "classification": "party",
@@ -193,8 +193,8 @@
     },
     {
       "name": {
-        "lang:ko_KR": "정의당 (대한민국)",
-        "lang:en_US": "Justice Party (South Korea)"
+        "lang:ko": "정의당 (대한민국)",
+        "lang:en": "Justice Party (South Korea)"
       },
       "id": "Q487520",
       "classification": "party",
@@ -223,8 +223,8 @@
         "Q50265926"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Busan",
@@ -248,8 +248,8 @@
         "Q50615886"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Daejeon",
@@ -273,8 +273,8 @@
         "Q50614705"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Daegu",
@@ -298,8 +298,8 @@
         "Q50274663"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 특별자치시",
-        "lang:en_US": "special autonomous city in South Korea"
+        "lang:ko": "대한민국의 특별자치시",
+        "lang:en": "special autonomous city in South Korea"
       },
       "name": {
         "lang:en_US": "Sejong Special Self-Governing City",
@@ -323,8 +323,8 @@
         "Q50617475"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Incheon",
@@ -348,8 +348,8 @@
         "Q12583545"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gyeonggi-do",
@@ -373,8 +373,8 @@
         "Q50619326"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Chungcheongbuk-do",
@@ -398,8 +398,8 @@
         "Q50619614"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Chungcheongnam-do",
@@ -423,8 +423,8 @@
         "Q12583022"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gangwon-do",
@@ -448,8 +448,8 @@
         "Q50619685"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gyeongsangnam-do",
@@ -473,8 +473,8 @@
         "Q50619415"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Gyeongsangbuk-do",
@@ -498,8 +498,8 @@
         "Q50619493"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Jeollabuk-do",
@@ -523,8 +523,8 @@
         "Q12615101"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 도",
-        "lang:en_US": "province of South Korea"
+        "lang:ko": "대한민국의 도",
+        "lang:en": "province of South Korea"
       },
       "name": {
         "lang:en_US": "Jeollanam-do",
@@ -548,8 +548,8 @@
         "Q50275066"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 특별자치도",
-        "lang:en_US": "Special Self-governing Province of South Korea"
+        "lang:ko": "대한민국의 특별자치도",
+        "lang:en": "Special Self-governing Province of South Korea"
       },
       "name": {
         "lang:en_US": "Jeju Special Self-Governing Province",
@@ -573,8 +573,8 @@
         "Q50619818"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Ulsan",
@@ -598,8 +598,8 @@
         "Q50616327"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 광역시",
-        "lang:en_US": "metropolitan city of South Korea"
+        "lang:ko": "대한민국의 광역시",
+        "lang:en": "metropolitan city of South Korea"
       },
       "name": {
         "lang:en_US": "Gwangju",
@@ -623,8 +623,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 종로구"
@@ -647,8 +647,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 고양시갑"
@@ -671,8 +671,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 금정구"
@@ -695,8 +695,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "세종특별자치시"
@@ -719,8 +719,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도 제주시갑"
@@ -743,8 +743,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 중구영도구"
@@ -767,8 +767,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 동작구갑"
@@ -791,8 +791,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청북도 청주시흥덕구"
@@ -815,8 +815,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 동두천시연천군"
@@ -839,8 +839,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강북구을"
@@ -863,8 +863,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 광주시을"
@@ -887,8 +887,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 마포구갑"
@@ -911,8 +911,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 구로구을"
@@ -935,8 +935,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 창원시마산회원구"
@@ -959,8 +959,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대전광역시 중구"
@@ -983,8 +983,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 남원시임실군순창군"
@@ -1007,8 +1007,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "강원도 강릉시"
@@ -1031,8 +1031,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "광주광역시 서구갑"
@@ -1055,8 +1055,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 계양구을"
@@ -1079,8 +1079,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 천안시갑"
@@ -1103,8 +1103,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 여주시양평군"
@@ -1127,8 +1127,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 광진구을"
@@ -1151,8 +1151,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "강원도 속초시고성군양양군"
@@ -1175,8 +1175,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 안성시"
@@ -1199,8 +1199,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 중구동구강화군옹진군"
@@ -1223,8 +1223,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 서대문구갑"
@@ -1247,8 +1247,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 금천구"
@@ -1271,8 +1271,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 포항시북구"
@@ -1295,8 +1295,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 서산시태안군"
@@ -1319,8 +1319,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 광명시을"
@@ -1343,8 +1343,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 김포시갑"
@@ -1367,8 +1367,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 수성구갑"
@@ -1391,8 +1391,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 연제구"
@@ -1415,8 +1415,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 익산시을"
@@ -1439,8 +1439,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 오산시"
@@ -1463,8 +1463,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "울산광역시 중구"
@@ -1487,8 +1487,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 달서구갑"
@@ -1511,8 +1511,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 중구성동구갑"
@@ -1535,8 +1535,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 부산진구을"
@@ -1559,8 +1559,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대전광역시 동구"
@@ -1583,8 +1583,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대전광역시 서구갑"
@@ -1607,8 +1607,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 북구을"
@@ -1631,8 +1631,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 달서구병"
@@ -1655,8 +1655,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 익산시갑"
@@ -1679,8 +1679,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 연수구을"
@@ -1703,8 +1703,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 영천시청도군"
@@ -1727,8 +1727,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청북도 보은군옥천군영동군괴산군"
@@ -1751,8 +1751,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청북도 청주시청원구"
@@ -1775,8 +1775,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 성남시분당구을"
@@ -1799,8 +1799,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 동작구을"
@@ -1823,8 +1823,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 천안시병"
@@ -1847,8 +1847,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도 제주시을"
@@ -1871,8 +1871,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 영양군영덕군봉화군울진군"
@@ -1895,8 +1895,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 성북구갑"
@@ -1919,8 +1919,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 안산시단원구을"
@@ -1943,8 +1943,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "광주광역시 동구남구갑"
@@ -1967,8 +1967,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 안산시단원구갑"
@@ -1991,8 +1991,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강서구을"
@@ -2015,8 +2015,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 남구을"
@@ -2039,8 +2039,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 광명시갑"
@@ -2063,8 +2063,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 구미시을"
@@ -2087,8 +2087,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 안양시동안구갑"
@@ -2111,8 +2111,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 전주시갑"
@@ -2135,8 +2135,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 완주군진안군무주군장수군"
@@ -2159,8 +2159,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 부천시원미구갑"
@@ -2183,8 +2183,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 영등포구을"
@@ -2207,8 +2207,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 의정부시갑"
@@ -2231,8 +2231,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청북도 청주시상당구"
@@ -2255,8 +2255,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "강원도 원주시갑"
@@ -2279,8 +2279,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 성북구을"
@@ -2303,8 +2303,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청북도 증평군진천군음성군"
@@ -2327,8 +2327,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 동대문구을"
@@ -2351,8 +2351,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대전광역시 유성구갑"
@@ -2375,8 +2375,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 서초구을"
@@ -2399,8 +2399,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 포항시남구울릉군"
@@ -2423,8 +2423,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 고흥군보성군장흥군강진군"
@@ -2447,8 +2447,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 진주시갑"
@@ -2471,8 +2471,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 부평구을"
@@ -2495,8 +2495,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 북구갑"
@@ -2519,8 +2519,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 전주시병"
@@ -2543,8 +2543,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "강원도 태백시횡성군영월군평창군정선군"
@@ -2567,8 +2567,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 영주시문경시예천군"
@@ -2591,8 +2591,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 전주시을"
@@ -2615,8 +2615,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 노원구병"
@@ -2639,8 +2639,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 북구강서구갑"
@@ -2663,8 +2663,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 의정부시을"
@@ -2687,8 +2687,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 구로구갑"
@@ -2711,8 +2711,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 안양시만안구"
@@ -2735,8 +2735,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 노원구을"
@@ -2759,8 +2759,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 부천시오정구"
@@ -2783,8 +2783,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 목포시"
@@ -2807,8 +2807,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 성남시분당구갑"
@@ -2831,8 +2831,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 해운대구을"
@@ -2855,8 +2855,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 여수시갑"
@@ -2879,8 +2879,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 김제시부안군"
@@ -2903,8 +2903,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 남양주시갑"
@@ -2927,8 +2927,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강남구병"
@@ -2951,8 +2951,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대전광역시 대덕구"
@@ -2975,8 +2975,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 의왕시과천시"
@@ -2999,8 +2999,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 당진시"
@@ -3023,8 +3023,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 시흥시갑"
@@ -3047,8 +3047,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 고령군성주군칠곡군"
@@ -3071,8 +3071,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 서구동구"
@@ -3095,8 +3095,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 영암군무안군신안군"
@@ -3119,8 +3119,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 공주시부여군청양군"
@@ -3143,8 +3143,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 송파구갑"
@@ -3167,8 +3167,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강동구을"
@@ -3191,8 +3191,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 평택시갑"
@@ -3215,8 +3215,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강북구갑"
@@ -3239,8 +3239,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 달서구을"
@@ -3263,8 +3263,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 중랑구갑"
@@ -3287,8 +3287,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "광주광역시 북구을"
@@ -3311,8 +3311,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 부산진구갑"
@@ -3335,8 +3335,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 노원구갑"
@@ -3359,8 +3359,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 안양시동안구을"
@@ -3383,8 +3383,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 양천구갑"
@@ -3407,8 +3407,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "광주광역시 광산구갑"
@@ -3431,8 +3431,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "강원도 동해시삼척시"
@@ -3455,8 +3455,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 은평구갑"
@@ -3479,8 +3479,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 창원시성산구"
@@ -3503,8 +3503,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 부천시원미구을"
@@ -3527,8 +3527,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 송파구병"
@@ -3551,8 +3551,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 순천시"
@@ -3575,8 +3575,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 송파구을"
@@ -3599,8 +3599,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 김해시갑"
@@ -3623,8 +3623,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 담양군함평군영광군장성군"
@@ -3647,8 +3647,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 이천시"
@@ -3671,8 +3671,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 양주시"
@@ -3695,8 +3695,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 동구갑"
@@ -3719,8 +3719,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 광진구갑"
@@ -3743,8 +3743,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 군포시을"
@@ -3767,8 +3767,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 안동시"
@@ -3791,8 +3791,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 화성시병"
@@ -3815,8 +3815,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 사상구"
@@ -3839,8 +3839,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강동구갑"
@@ -3863,8 +3863,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 영등포구갑"
@@ -3887,8 +3887,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 성남시중원구"
@@ -3911,8 +3911,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 서초구갑"
@@ -3935,8 +3935,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 김해시을"
@@ -3959,8 +3959,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 도봉구갑"
@@ -3983,8 +3983,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 창원시마산합포구"
@@ -4007,8 +4007,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 사하구을"
@@ -4031,8 +4031,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 보령시서천군"
@@ -4055,8 +4055,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 수원시정"
@@ -4079,8 +4079,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 동대문구갑"
@@ -4103,8 +4103,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 용인시병"
@@ -4127,8 +4127,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 사천시남해군하동군"
@@ -4151,8 +4151,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "울산광역시 울주군"
@@ -4175,8 +4175,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "강원도 원주시을"
@@ -4199,8 +4199,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청북도 제천시단양군"
@@ -4223,8 +4223,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 통영시고성군"
@@ -4247,8 +4247,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 수원시을"
@@ -4271,8 +4271,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 진주시을"
@@ -4295,8 +4295,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대전광역시 서구을"
@@ -4319,8 +4319,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대전광역시 유성구을"
@@ -4343,8 +4343,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 군산시"
@@ -4367,8 +4367,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "울산광역시 남구을"
@@ -4391,8 +4391,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청북도 청주시서원구"
@@ -4415,8 +4415,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 파주시갑"
@@ -4439,8 +4439,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 상주시군위군의성군청송군"
@@ -4463,8 +4463,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 마포구을"
@@ -4487,8 +4487,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 동구을"
@@ -4511,8 +4511,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 화성시갑"
@@ -4535,8 +4535,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 서구을"
@@ -4559,8 +4559,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 중랑구을"
@@ -4583,8 +4583,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강남구갑"
@@ -4607,8 +4607,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "울산광역시 남구갑"
@@ -4631,8 +4631,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 관악구을"
@@ -4655,8 +4655,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 여수시을"
@@ -4679,8 +4679,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 남동구갑"
@@ -4703,8 +4703,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 중구성동구을"
@@ -4727,8 +4727,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 고양시병"
@@ -4751,8 +4751,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 광주시갑"
@@ -4775,8 +4775,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 달성군"
@@ -4799,8 +4799,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 성남시수정구"
@@ -4823,8 +4823,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강서구병"
@@ -4847,8 +4847,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 수원시병"
@@ -4871,8 +4871,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 남구갑"
@@ -4895,8 +4895,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 김포시을"
@@ -4919,8 +4919,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 수성구을"
@@ -4943,8 +4943,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 부평구갑"
@@ -4967,8 +4967,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 군포시갑"
@@ -4991,8 +4991,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 남양주시병"
@@ -5015,8 +5015,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 사하구갑"
@@ -5039,8 +5039,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 양산시을"
@@ -5063,8 +5063,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 화성시을"
@@ -5087,8 +5087,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "광주광역시 북구갑"
@@ -5111,8 +5111,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "광주광역시 서구을"
@@ -5135,8 +5135,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 계양구갑"
@@ -5159,8 +5159,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 수영구"
@@ -5183,8 +5183,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 부천시소사구"
@@ -5207,8 +5207,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 기장군"
@@ -5231,8 +5231,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 안산시상록구갑"
@@ -5255,8 +5255,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 나주시화순군"
@@ -5279,8 +5279,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "강원도 홍천군철원군화천군양구군인제군"
@@ -5303,8 +5303,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 수원시갑"
@@ -5327,8 +5327,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 시흥시을"
@@ -5351,8 +5351,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 논산시계룡시금산군"
@@ -5375,8 +5375,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 남양주시을"
@@ -5399,8 +5399,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 천안시을"
@@ -5423,8 +5423,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 용인시을"
@@ -5447,8 +5447,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 파주시을"
@@ -5471,8 +5471,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "광주광역시 동구남구을"
@@ -5495,8 +5495,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 용인시갑"
@@ -5519,8 +5519,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 남구갑"
@@ -5543,8 +5543,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 창원시진해구"
@@ -5567,8 +5567,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라북도 정읍시고창군"
@@ -5591,8 +5591,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "광주광역시 광산구을"
@@ -5615,8 +5615,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 고양시정"
@@ -5639,8 +5639,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 구미시갑"
@@ -5663,8 +5663,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 서구갑"
@@ -5687,8 +5687,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 양천구을"
@@ -5711,8 +5711,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 광양시곡성군구례군"
@@ -5735,8 +5735,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 경산시"
@@ -5759,8 +5759,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 밀양시의령군함안군창녕군"
@@ -5783,8 +5783,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 관악구갑"
@@ -5807,8 +5807,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 남동구을"
@@ -5831,8 +5831,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 동래구"
@@ -5855,8 +5855,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 아산시갑"
@@ -5879,8 +5879,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 김천시"
@@ -5903,8 +5903,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 서대문구을"
@@ -5927,8 +5927,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 창원시의창구"
@@ -5951,8 +5951,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 수원시무"
@@ -5975,8 +5975,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 포천시가평군"
@@ -5999,8 +5999,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 평택시을"
@@ -6023,8 +6023,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 양산시갑"
@@ -6047,8 +6047,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 은평구을"
@@ -6071,8 +6071,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "강원도 춘천시"
@@ -6095,8 +6095,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강남구을"
@@ -6119,8 +6119,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 중구남구"
@@ -6143,8 +6143,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 용인시정"
@@ -6167,8 +6167,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 안산시상록구을"
@@ -6191,8 +6191,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청북도 충주시"
@@ -6215,8 +6215,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 홍성군예산군"
@@ -6239,8 +6239,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 도봉구을"
@@ -6263,8 +6263,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 강서구갑"
@@ -6287,8 +6287,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 고양시을"
@@ -6311,8 +6311,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 북구강서구을"
@@ -6335,8 +6335,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 남구을"
@@ -6359,8 +6359,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "충청남도 아산시을"
@@ -6383,8 +6383,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "부산광역시 해운대구갑"
@@ -6407,8 +6407,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 산청군함양군거창군합천군"
@@ -6431,8 +6431,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "전라남도 해남군완도군진도군"
@@ -6455,8 +6455,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "인천광역시 연수구갑"
@@ -6479,8 +6479,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "비례대표 국회의원 선거구",
@@ -6504,8 +6504,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "제주특별자치도 서귀포시"
@@ -6528,8 +6528,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "울산광역시 동구"
@@ -6552,8 +6552,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상남도 거제시"
@@ -6576,8 +6576,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경상북도 경주시"
@@ -6600,8 +6600,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 구리시"
@@ -6624,8 +6624,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "경기도 하남시"
@@ -6648,8 +6648,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "울산광역시 북구"
@@ -6672,8 +6672,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "서울특별시 용산구"
@@ -6696,8 +6696,8 @@
         "Q14850694"
       ],
       "type": {
-        "lang:ko_KR": "대한민국 국회의원 선거구",
-        "lang:en_US": "Constituency of the National Assembly of South Korea"
+        "lang:ko": "대한민국 국회의원 선거구",
+        "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
         "lang:ko_KR": "대구광역시 서구"
@@ -6720,8 +6720,8 @@
         "Q488289"
       ],
       "type": {
-        "lang:ko_KR": "대한민국의 특별시",
-        "lang:en_US": "special city of South Korea"
+        "lang:ko": "대한민국의 특별시",
+        "lang:en": "special city of South Korea"
       },
       "name": {
         "lang:en_US": "Seoul",
@@ -6745,7 +6745,7 @@
         "Q6296418"
       ],
       "type": {
-        "lang:en_US": "country"
+        "lang:en": "country"
       },
       "name": {
         "lang:ko_KR": "대한민국",
@@ -6764,13 +6764,13 @@
       "start_date": "2016-05-30",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:ko_KR": "국회의원",
-        "lang:en_US": "member of parliament"
+        "lang:ko": "국회의원",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q14850694",
       "role": {
-        "lang:ko_KR": "대한민국의 국회의원",
-        "lang:en_US": "Member of National Assembly of South Korea"
+        "lang:ko": "대한민국의 국회의원",
+        "lang:en": "Member of National Assembly of South Korea"
       }
     },
     {
@@ -6782,13 +6782,13 @@
       "start_date": "2016-05-30",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:ko_KR": "국회의원",
-        "lang:en_US": "member of parliament"
+        "lang:ko": "국회의원",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q14850694",
       "role": {
-        "lang:ko_KR": "대한민국의 국회의원",
-        "lang:en_US": "Member of National Assembly of South Korea"
+        "lang:ko": "대한민국의 국회의원",
+        "lang:en": "Member of National Assembly of South Korea"
       }
     },
     {
@@ -6800,13 +6800,13 @@
       "start_date": "2016-05-30",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:ko_KR": "국회의원",
-        "lang:en_US": "member of parliament"
+        "lang:ko": "국회의원",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q14850694",
       "role": {
-        "lang:ko_KR": "대한민국의 국회의원",
-        "lang:en_US": "Member of National Assembly of South Korea"
+        "lang:ko": "대한민국의 국회의원",
+        "lang:en": "Member of National Assembly of South Korea"
       }
     },
     {
@@ -6815,13 +6815,13 @@
       "organization_id": "Q494162",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:ko_KR": "국회의원",
-        "lang:en_US": "member of parliament"
+        "lang:ko": "국회의원",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q14850694",
       "role": {
-        "lang:ko_KR": "대한민국의 국회의원",
-        "lang:en_US": "Member of National Assembly of South Korea"
+        "lang:ko": "대한민국의 국회의원",
+        "lang:en": "Member of National Assembly of South Korea"
       }
     },
     {
@@ -6833,13 +6833,13 @@
       "start_date": "2016-05-30",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:ko_KR": "국회의원",
-        "lang:en_US": "member of parliament"
+        "lang:ko": "국회의원",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q14850694",
       "role": {
-        "lang:ko_KR": "대한민국의 국회의원",
-        "lang:en_US": "Member of National Assembly of South Korea"
+        "lang:ko": "대한민국의 국회의원",
+        "lang:en": "Member of National Assembly of South Korea"
       }
     },
     {
@@ -6849,13 +6849,13 @@
       "start_date": "2017-06-01",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:ko_KR": "국회의원",
-        "lang:en_US": "member of parliament"
+        "lang:ko": "국회의원",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q14850694",
       "role": {
-        "lang:ko_KR": "대한민국의 국회의원",
-        "lang:en_US": "Member of National Assembly of South Korea"
+        "lang:ko": "대한민국의 국회의원",
+        "lang:en": "Member of National Assembly of South Korea"
       }
     },
     {
@@ -6864,13 +6864,13 @@
       "organization_id": "Q494162",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:ko_KR": "국회의원",
-        "lang:en_US": "member of parliament"
+        "lang:ko": "국회의원",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q14850694",
       "role": {
-        "lang:ko_KR": "대한민국의 국회의원",
-        "lang:en_US": "Member of National Assembly of South Korea"
+        "lang:ko": "대한민국의 국회의원",
+        "lang:en": "Member of National Assembly of South Korea"
       }
     },
     {
@@ -6881,13 +6881,13 @@
       "start_date": "2016-05-30",
       "role_superclass_code": "Q486839",
       "role_superclass": {
-        "lang:ko_KR": "국회의원",
-        "lang:en_US": "member of parliament"
+        "lang:ko": "국회의원",
+        "lang:en": "member of parliament"
       },
       "role_code": "Q14850694",
       "role": {
-        "lang:ko_KR": "대한민국의 국회의원",
-        "lang:en_US": "Member of National Assembly of South Korea"
+        "lang:ko": "대한민국의 국회의원",
+        "lang:en": "Member of National Assembly of South Korea"
       }
     }
   ]


### PR DESCRIPTION
This moves this proto-commons- repo to use Wikidata language codes in the generated files, instead of Facebook locale codes, after the change introduced by be979f9 of commons-builder (later fixed in 0e34a06).