### PR TITLE
Fix boundary lang columns

### DIFF
--- a/boundaries/build/index.json
+++ b/boundaries/build/index.json
@@ -9,8 +9,8 @@
     ],
     "area_type_wikidata_item_id": "Q6256",
     "name_columns": {
-      "lang:ko_KR": "NAME",
-      "lang:en_US": "NAME_EN"
+      "lang:ko": "NAME",
+      "lang:en": "NAME_EN"
     }
   },
   {
@@ -23,8 +23,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:42",
@@ -41,8 +41,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:41",
@@ -59,8 +59,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:48",
@@ -77,8 +77,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:47",
@@ -95,8 +95,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:29",
@@ -113,8 +113,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:27",
@@ -131,8 +131,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:30",
@@ -149,8 +149,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:26",
@@ -167,8 +167,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/special-city:11",
@@ -185,8 +185,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/ssg-city:50",
@@ -203,8 +203,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:31",
@@ -221,8 +221,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:28",
@@ -239,8 +239,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:46",
@@ -257,8 +257,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:45",
@@ -275,8 +275,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/ssg-province:49",
@@ -293,8 +293,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:44",
@@ -311,8 +311,8 @@
       }
     ],
     "name_columns": {
-      "lang:en_US": "NAME_EN",
-      "lang:ko_KR": "NAME"
+      "lang:en": "NAME_EN",
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:43",
@@ -329,7 +329,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/special-city:11",
@@ -346,7 +346,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/met-city:29",
@@ -363,7 +363,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/province:45",
@@ -380,7 +380,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/province:41",
@@ -397,7 +397,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/met-city:28",
@@ -414,7 +414,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/met-city:31",
@@ -431,7 +431,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/province:47",
@@ -448,7 +448,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/ssg-province:49",
@@ -465,7 +465,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/met-city:27",
@@ -482,7 +482,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/province:42",
@@ -499,7 +499,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/province:44",
@@ -516,7 +516,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/province:48",
@@ -533,7 +533,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/province:46",
@@ -550,7 +550,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/met-city:30",
@@ -567,7 +567,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/ssg-city:50",
@@ -584,7 +584,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/met-city:26",
@@ -601,7 +601,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "name"
+      "lang:ko": "name"
     },
     "filter": {
       "match": "country:kr/province:43",
@@ -618,7 +618,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     }
   },
   {
@@ -631,8 +631,8 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME",
-      "lang:en_US": "NAME_EN"
+      "lang:ko": "NAME",
+      "lang:en": "NAME_EN"
     }
   },
   {
@@ -645,7 +645,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:48",
@@ -662,7 +662,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/ssg-city:50",
@@ -679,7 +679,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:30",
@@ -696,7 +696,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:44",
@@ -713,7 +713,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:28",
@@ -730,7 +730,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:43",
@@ -747,7 +747,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:26",
@@ -764,7 +764,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:27",
@@ -781,7 +781,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/ssg-province:49",
@@ -798,7 +798,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:31",
@@ -815,7 +815,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/met-city:29",
@@ -832,7 +832,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/special-city:11",
@@ -849,7 +849,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:47",
@@ -866,7 +866,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:41",
@@ -883,7 +883,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:42",
@@ -900,7 +900,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:46",
@@ -917,7 +917,7 @@
       }
     ],
     "name_columns": {
-      "lang:ko_KR": "NAME"
+      "lang:ko": "NAME"
     },
     "filter": {
       "match": "country:kr/province:45",

--- a/executive/Q12583023/current/popolo-m17n.json
+++ b/executive/Q12583023/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gangwon-do",
-        "lang:ko_KR": "강원도"
+        "lang:en": "Gangwon-do",
+        "lang:ko": "강원도"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12583547/current/popolo-m17n.json
+++ b/executive/Q12583547/current/popolo-m17n.json
@@ -72,8 +72,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gyeonggi-do",
-        "lang:ko_KR": "경기도"
+        "lang:en": "Gyeonggi-do",
+        "lang:ko": "경기도"
       },
       "parent_id": "Q884"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12583737/current/popolo-m17n.json
+++ b/executive/Q12583737/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gyeongsangbuk-do",
-        "lang:ko_KR": "경상북도"
+        "lang:en": "Gyeongsangbuk-do",
+        "lang:ko": "경상북도"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12585108/current/popolo-m17n.json
+++ b/executive/Q12585108/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Gwangju",
-        "lang:ko_KR": "광주광역시"
+        "lang:en": "Gwangju",
+        "lang:ko": "광주광역시"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12585780/current/popolo-m17n.json
+++ b/executive/Q12585780/current/popolo-m17n.json
@@ -71,8 +71,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12613488/current/popolo-m17n.json
+++ b/executive/Q12613488/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Incheon",
-        "lang:ko_KR": "인천광역시"
+        "lang:en": "Incheon",
+        "lang:ko": "인천광역시"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12615100/current/popolo-m17n.json
+++ b/executive/Q12615100/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Jeollanam-do",
-        "lang:ko_KR": "전라남도"
+        "lang:en": "Jeollanam-do",
+        "lang:ko": "전라남도"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12615114/current/popolo-m17n.json
+++ b/executive/Q12615114/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Jeollabuk-do",
-        "lang:ko_KR": "전라북도"
+        "lang:en": "Jeollabuk-do",
+        "lang:ko": "전라북도"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12616502/current/popolo-m17n.json
+++ b/executive/Q12616502/current/popolo-m17n.json
@@ -72,8 +72,8 @@
         "lang:en": "Special Self-governing Province of South Korea"
       },
       "name": {
-        "lang:en_US": "Jeju Special Self-Governing Province",
-        "lang:ko_KR": "제주특별자치도"
+        "lang:en": "Jeju Special Self-Governing Province",
+        "lang:ko": "제주특별자치도"
       },
       "parent_id": "Q884"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12620195/current/popolo-m17n.json
+++ b/executive/Q12620195/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Chungcheongnam-do",
-        "lang:ko_KR": "충청남도"
+        "lang:en": "Chungcheongnam-do",
+        "lang:ko": "충청남도"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q12620207/current/popolo-m17n.json
+++ b/executive/Q12620207/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Chungcheongbuk-do",
-        "lang:ko_KR": "충청북도"
+        "lang:en": "Chungcheongbuk-do",
+        "lang:ko": "충청북도"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q16093739/current/popolo-m17n.json
+++ b/executive/Q16093739/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gyeongsangnam-do",
-        "lang:ko_KR": "경상남도"
+        "lang:en": "Gyeongsangnam-do",
+        "lang:ko": "경상남도"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q16095354/current/popolo-m17n.json
+++ b/executive/Q16095354/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Daegu",
-        "lang:ko_KR": "대구광역시"
+        "lang:en": "Daegu",
+        "lang:ko": "대구광역시"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q16095517/current/popolo-m17n.json
+++ b/executive/Q16095517/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Daejeon",
-        "lang:ko_KR": "대전광역시"
+        "lang:en": "Daejeon",
+        "lang:ko": "대전광역시"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q16097618/current/popolo-m17n.json
+++ b/executive/Q16097618/current/popolo-m17n.json
@@ -72,8 +72,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Busan",
-        "lang:ko_KR": "부산광역시"
+        "lang:en": "Busan",
+        "lang:ko": "부산광역시"
       },
       "parent_id": "Q884"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q16097915/current/popolo-m17n.json
+++ b/executive/Q16097915/current/popolo-m17n.json
@@ -72,8 +72,8 @@
         "lang:en": "special autonomous city in South Korea"
       },
       "name": {
-        "lang:en_US": "Sejong Special Self-Governing City",
-        "lang:ko_KR": "세종특별자치시"
+        "lang:en": "Sejong Special Self-Governing City",
+        "lang:ko": "세종특별자치시"
       },
       "parent_id": "Q884"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q16099053/current/popolo-m17n.json
+++ b/executive/Q16099053/current/popolo-m17n.json
@@ -26,8 +26,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Ulsan",
-        "lang:ko_KR": "울산광역시"
+        "lang:en": "Ulsan",
+        "lang:ko": "울산광역시"
       },
       "parent_id": "Q884"
     },
@@ -50,8 +50,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/executive/Q623789/current/popolo-m17n.json
+++ b/executive/Q623789/current/popolo-m17n.json
@@ -72,8 +72,8 @@
         "lang:en": "special city of South Korea"
       },
       "name": {
-        "lang:en_US": "Seoul",
-        "lang:ko_KR": "서울특별시"
+        "lang:en": "Seoul",
+        "lang:ko": "서울특별시"
       },
       "parent_id": "Q884"
     },
@@ -96,8 +96,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q12601388/Q50798355/popolo-m17n.json
+++ b/legislative/Q12601388/Q50798355/popolo-m17n.json
@@ -238,7 +238,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "성동구제1선거구"
+        "lang:ko": "성동구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -262,7 +262,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "노원구제1선거구"
+        "lang:ko": "노원구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -286,7 +286,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "양천구제1선거구"
+        "lang:ko": "양천구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -310,7 +310,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "송파구제6선거구"
+        "lang:ko": "송파구제6선거구"
       },
       "parent_id": "Q8684"
     },
@@ -334,7 +334,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "도봉구제1선거구"
+        "lang:ko": "도봉구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -358,7 +358,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강남구제4선거구"
+        "lang:ko": "강남구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -382,7 +382,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "동작구제1선거구"
+        "lang:ko": "동작구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -406,7 +406,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "은평구제1선거구"
+        "lang:ko": "은평구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -430,7 +430,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "송파구제4선거구"
+        "lang:ko": "송파구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -454,7 +454,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "영등포구제3선거구"
+        "lang:ko": "영등포구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -478,7 +478,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강남구제1선거구"
+        "lang:ko": "강남구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -502,7 +502,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "서초구제4선거구"
+        "lang:ko": "서초구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -526,7 +526,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "송파구제2선거구"
+        "lang:ko": "송파구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -550,7 +550,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "성북구제2선거구"
+        "lang:ko": "성북구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -574,7 +574,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "구로구제4선거구"
+        "lang:ko": "구로구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -598,7 +598,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "성북구제4선거구"
+        "lang:ko": "성북구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -622,7 +622,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "노원구제2선거구"
+        "lang:ko": "노원구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -646,7 +646,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강북구제4선거구"
+        "lang:ko": "강북구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -670,7 +670,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "마포구제2선거구"
+        "lang:ko": "마포구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -694,7 +694,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "송파구제1선거구"
+        "lang:ko": "송파구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -718,7 +718,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "중랑구제1선거구"
+        "lang:ko": "중랑구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -742,7 +742,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "중랑구제2선거구"
+        "lang:ko": "중랑구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -766,7 +766,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "구로구제1선거구"
+        "lang:ko": "구로구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -790,7 +790,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강서구제1선거구"
+        "lang:ko": "강서구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -814,7 +814,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "구로구제3선거구"
+        "lang:ko": "구로구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -838,7 +838,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강남구제2선거구"
+        "lang:ko": "강남구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -862,7 +862,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "서대문구제2선거구"
+        "lang:ko": "서대문구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -886,7 +886,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강남구제3선거구"
+        "lang:ko": "강남구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -910,7 +910,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "동작구제3선거구"
+        "lang:ko": "동작구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -934,7 +934,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "관악구제2선거구"
+        "lang:ko": "관악구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -958,7 +958,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "은평구제3선거구"
+        "lang:ko": "은평구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -982,7 +982,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "서초구제3선거구"
+        "lang:ko": "서초구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1006,7 +1006,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "중구제2선거구"
+        "lang:ko": "중구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1030,7 +1030,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "성동구제3선거구"
+        "lang:ko": "성동구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1054,7 +1054,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "노원구제3선거구"
+        "lang:ko": "노원구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1078,7 +1078,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "송파구제5선거구"
+        "lang:ko": "송파구제5선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1102,7 +1102,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "광진구제1선거구"
+        "lang:ko": "광진구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1126,7 +1126,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "중구제1선거구"
+        "lang:ko": "중구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1150,7 +1150,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "동대문구제3선거구"
+        "lang:ko": "동대문구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1174,7 +1174,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "노원구제6선거구"
+        "lang:ko": "노원구제6선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1198,7 +1198,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "용산구제1선거구"
+        "lang:ko": "용산구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1222,7 +1222,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강서구제3선거구"
+        "lang:ko": "강서구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1246,7 +1246,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "은평구제2선거구"
+        "lang:ko": "은평구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1270,7 +1270,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "송파구제3선거구"
+        "lang:ko": "송파구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1294,7 +1294,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강동구제3선거구"
+        "lang:ko": "강동구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1318,7 +1318,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "금천구제1선거구"
+        "lang:ko": "금천구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1342,7 +1342,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강북구제2선거구"
+        "lang:ko": "강북구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1366,7 +1366,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "서대문구제3선거구"
+        "lang:ko": "서대문구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1390,7 +1390,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강동구제1선거구"
+        "lang:ko": "강동구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1414,7 +1414,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "종로구제2선거구"
+        "lang:ko": "종로구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1438,7 +1438,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강동구제2선거구"
+        "lang:ko": "강동구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1462,7 +1462,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강북구제3선거구"
+        "lang:ko": "강북구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1486,7 +1486,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "도봉구제2선거구"
+        "lang:ko": "도봉구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1510,7 +1510,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "동작구제4선거구"
+        "lang:ko": "동작구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1534,7 +1534,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "광진구제3선거구"
+        "lang:ko": "광진구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1558,7 +1558,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "성동구제4선거구"
+        "lang:ko": "성동구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1582,7 +1582,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "광진구제2선거구"
+        "lang:ko": "광진구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1606,7 +1606,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "서대문구제4선거구"
+        "lang:ko": "서대문구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1630,7 +1630,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "서초구제2선거구"
+        "lang:ko": "서초구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1654,7 +1654,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "영등포구제4선거구"
+        "lang:ko": "영등포구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1678,7 +1678,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강서구제4선거구"
+        "lang:ko": "강서구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1702,7 +1702,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "성동구제2선거구"
+        "lang:ko": "성동구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1726,7 +1726,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "동대문구제1선거구"
+        "lang:ko": "동대문구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1750,7 +1750,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "중랑구제4선거구"
+        "lang:ko": "중랑구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1774,7 +1774,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "중랑구제3선거구"
+        "lang:ko": "중랑구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1798,7 +1798,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "마포구제3선거구"
+        "lang:ko": "마포구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1822,7 +1822,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "성북구제3선거구"
+        "lang:ko": "성북구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1846,7 +1846,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "관악구제4선거구"
+        "lang:ko": "관악구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1870,7 +1870,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "동대문구제2선거구"
+        "lang:ko": "동대문구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1894,7 +1894,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "광진구제4선거구"
+        "lang:ko": "광진구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1918,7 +1918,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "구로구제2선거구"
+        "lang:ko": "구로구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1942,7 +1942,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강동구제4선거구"
+        "lang:ko": "강동구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1966,7 +1966,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "관악구제3선거구"
+        "lang:ko": "관악구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -1990,7 +1990,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "노원구제4선거구"
+        "lang:ko": "노원구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2014,7 +2014,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "양천구제2선거구"
+        "lang:ko": "양천구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2038,7 +2038,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "서초구제1선거구"
+        "lang:ko": "서초구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2062,7 +2062,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "영등포구제2선거구"
+        "lang:ko": "영등포구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2086,7 +2086,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "금천구제2선거구"
+        "lang:ko": "금천구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2110,7 +2110,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "성북구제1선거구"
+        "lang:ko": "성북구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2134,7 +2134,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "은평구제4선거구"
+        "lang:ko": "은평구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2158,7 +2158,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "영등포구제1선거구"
+        "lang:ko": "영등포구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2182,7 +2182,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "관악구제1선거구"
+        "lang:ko": "관악구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2206,7 +2206,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "동대문구제4선거구"
+        "lang:ko": "동대문구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2230,7 +2230,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "마포구제1선거구"
+        "lang:ko": "마포구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2254,7 +2254,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "마포구제4선거구"
+        "lang:ko": "마포구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2278,7 +2278,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "종로구제1선거구"
+        "lang:ko": "종로구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2302,7 +2302,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "양천구제4선거구"
+        "lang:ko": "양천구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2326,7 +2326,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "양천구제3선거구"
+        "lang:ko": "양천구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2350,7 +2350,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "노원구제5선거구"
+        "lang:ko": "노원구제5선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2374,7 +2374,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "용산구제2선거구"
+        "lang:ko": "용산구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2398,7 +2398,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "도봉구제4선거구"
+        "lang:ko": "도봉구제4선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2422,7 +2422,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "동작구제2선거구"
+        "lang:ko": "동작구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2446,7 +2446,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "서대문구제1선거구"
+        "lang:ko": "서대문구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2470,7 +2470,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강서구제2선거구"
+        "lang:ko": "강서구제2선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2494,7 +2494,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "강북구제1선거구"
+        "lang:ko": "강북구제1선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2518,7 +2518,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "도봉구제3선거구"
+        "lang:ko": "도봉구제3선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2542,7 +2542,7 @@
         "lang:en": "FLACS Council Constituency of Seoul"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 비례대표 선거구"
+        "lang:ko": "서울특별시 비례대표 선거구"
       },
       "parent_id": "Q8684"
     },
@@ -2566,8 +2566,8 @@
         "lang:en": "special city of South Korea"
       },
       "name": {
-        "lang:en_US": "Seoul",
-        "lang:ko_KR": "서울특별시"
+        "lang:en": "Seoul",
+        "lang:ko": "서울특별시"
       },
       "parent_id": "Q884"
     },
@@ -2590,8 +2590,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16093243/Q50798392/popolo-m17n.json
+++ b/legislative/Q16093243/Q50798392/popolo-m17n.json
@@ -244,8 +244,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gangwon-do",
-        "lang:ko_KR": "강원도"
+        "lang:en": "Gangwon-do",
+        "lang:ko": "강원도"
       },
       "parent_id": "Q884"
     },
@@ -269,7 +269,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "횡성군제2선거구"
+        "lang:ko": "횡성군제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -293,7 +293,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "평창군제2선거구"
+        "lang:ko": "평창군제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -317,7 +317,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "춘천시제4선거구"
+        "lang:ko": "춘천시제4선거구"
       },
       "parent_id": "Q41071"
     },
@@ -341,7 +341,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "평창군제1선거구"
+        "lang:ko": "평창군제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -365,7 +365,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "동해시제2선거구"
+        "lang:ko": "동해시제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -389,7 +389,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "강릉시제3선거구"
+        "lang:ko": "강릉시제3선거구"
       },
       "parent_id": "Q41071"
     },
@@ -413,7 +413,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "강릉시제1선거구"
+        "lang:ko": "강릉시제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -437,7 +437,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "원주시제5선거구"
+        "lang:ko": "원주시제5선거구"
       },
       "parent_id": "Q41071"
     },
@@ -461,7 +461,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "원주시제4선거구"
+        "lang:ko": "원주시제4선거구"
       },
       "parent_id": "Q41071"
     },
@@ -485,7 +485,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "홍천군제1선거구"
+        "lang:ko": "홍천군제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -509,7 +509,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "원주시제3선거구"
+        "lang:ko": "원주시제3선거구"
       },
       "parent_id": "Q41071"
     },
@@ -533,7 +533,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "원주시제2선거구"
+        "lang:ko": "원주시제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -557,7 +557,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "태백시제1선거구"
+        "lang:ko": "태백시제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -581,7 +581,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "양구군선거구"
+        "lang:ko": "양구군선거구"
       },
       "parent_id": "Q41071"
     },
@@ -605,7 +605,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "철원군제2선거구"
+        "lang:ko": "철원군제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -629,7 +629,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "고성군선거구"
+        "lang:ko": "고성군선거구"
       },
       "parent_id": "Q41071"
     },
@@ -653,7 +653,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "태백시제2선거구"
+        "lang:ko": "태백시제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -677,7 +677,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "정선군제2선거구"
+        "lang:ko": "정선군제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -701,7 +701,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "속초시제1선거구"
+        "lang:ko": "속초시제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -725,7 +725,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "삼척시제1선거구"
+        "lang:ko": "삼척시제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -749,7 +749,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "속초시제2선거구"
+        "lang:ko": "속초시제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -773,7 +773,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "춘천시제3선거구"
+        "lang:ko": "춘천시제3선거구"
       },
       "parent_id": "Q41071"
     },
@@ -797,7 +797,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "강릉시제4선거구"
+        "lang:ko": "강릉시제4선거구"
       },
       "parent_id": "Q41071"
     },
@@ -821,7 +821,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "정선군제1선거구"
+        "lang:ko": "정선군제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -845,7 +845,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "춘천시제1선거구"
+        "lang:ko": "춘천시제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -869,7 +869,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "홍천군제2선거구"
+        "lang:ko": "홍천군제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -893,7 +893,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "횡성군제1선거구"
+        "lang:ko": "횡성군제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -917,7 +917,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "화천군선거구"
+        "lang:ko": "화천군선거구"
       },
       "parent_id": "Q41071"
     },
@@ -941,7 +941,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "원주시제6선거구"
+        "lang:ko": "원주시제6선거구"
       },
       "parent_id": "Q41071"
     },
@@ -965,7 +965,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "삼척시제2선거구"
+        "lang:ko": "삼척시제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -989,7 +989,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "영월군제1선거구"
+        "lang:ko": "영월군제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1013,7 +1013,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "영월군제2선거구"
+        "lang:ko": "영월군제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1037,7 +1037,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "동해시제1선거구"
+        "lang:ko": "동해시제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1061,7 +1061,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "춘천시제5선거구"
+        "lang:ko": "춘천시제5선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1085,7 +1085,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "양양군선거구"
+        "lang:ko": "양양군선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1109,7 +1109,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "원주시제1선거구"
+        "lang:ko": "원주시제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1133,7 +1133,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "인제군선거구"
+        "lang:ko": "인제군선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1157,7 +1157,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "철원군제1선거구"
+        "lang:ko": "철원군제1선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1181,7 +1181,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "강릉시제2선거구"
+        "lang:ko": "강릉시제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1205,7 +1205,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "춘천시제2선거구"
+        "lang:ko": "춘천시제2선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1229,7 +1229,7 @@
         "lang:en": "FLACS Council Constituency of Gangwon Province"
       },
       "name": {
-        "lang:ko_KR": "강원도 비례대표 선거구"
+        "lang:ko": "강원도 비례대표 선거구"
       },
       "parent_id": "Q41071"
     },
@@ -1252,8 +1252,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16093885/Q50798239/popolo-m17n.json
+++ b/legislative/Q16093885/Q50798239/popolo-m17n.json
@@ -230,8 +230,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gyeongsangbuk-do",
-        "lang:ko_KR": "경상북도"
+        "lang:en": "Gyeongsangbuk-do",
+        "lang:ko": "경상북도"
       },
       "parent_id": "Q884"
     },
@@ -255,7 +255,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경산시제4선거구"
+        "lang:ko": "경산시제4선거구"
       },
       "parent_id": "Q41154"
     },
@@ -279,7 +279,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "예천군제1선거구"
+        "lang:ko": "예천군제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -303,7 +303,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "포항시제7선거구"
+        "lang:ko": "포항시제7선거구"
       },
       "parent_id": "Q41154"
     },
@@ -327,7 +327,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "안동시제2선거구"
+        "lang:ko": "안동시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -351,7 +351,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "청송군선거구"
+        "lang:ko": "청송군선거구"
       },
       "parent_id": "Q41154"
     },
@@ -375,7 +375,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "문경시제1선거구"
+        "lang:ko": "문경시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -399,7 +399,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "영양군선거구"
+        "lang:ko": "영양군선거구"
       },
       "parent_id": "Q41154"
     },
@@ -423,7 +423,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "봉화군선거구"
+        "lang:ko": "봉화군선거구"
       },
       "parent_id": "Q41154"
     },
@@ -447,7 +447,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "포항시제5선거구"
+        "lang:ko": "포항시제5선거구"
       },
       "parent_id": "Q41154"
     },
@@ -471,7 +471,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "구미시제6선거구"
+        "lang:ko": "구미시제6선거구"
       },
       "parent_id": "Q41154"
     },
@@ -495,7 +495,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "포항시제3선거구"
+        "lang:ko": "포항시제3선거구"
       },
       "parent_id": "Q41154"
     },
@@ -519,7 +519,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "칠곡군제1선거구"
+        "lang:ko": "칠곡군제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -543,7 +543,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경산시제1선거구"
+        "lang:ko": "경산시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -567,7 +567,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "문경시제2선거구"
+        "lang:ko": "문경시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -591,7 +591,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경주시제2선거구"
+        "lang:ko": "경주시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -615,7 +615,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "영주시제1선거구"
+        "lang:ko": "영주시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -639,7 +639,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "포항시제1선거구"
+        "lang:ko": "포항시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -663,7 +663,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "포항시제4선거구"
+        "lang:ko": "포항시제4선거구"
       },
       "parent_id": "Q41154"
     },
@@ -687,7 +687,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경주시제3선거구"
+        "lang:ko": "경주시제3선거구"
       },
       "parent_id": "Q41154"
     },
@@ -711,7 +711,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경주시제4선거구"
+        "lang:ko": "경주시제4선거구"
       },
       "parent_id": "Q41154"
     },
@@ -735,7 +735,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "군위군선거구"
+        "lang:ko": "군위군선거구"
       },
       "parent_id": "Q41154"
     },
@@ -759,7 +759,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "구미시제1선거구"
+        "lang:ko": "구미시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -783,7 +783,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "구미시제5선거구"
+        "lang:ko": "구미시제5선거구"
       },
       "parent_id": "Q41154"
     },
@@ -807,7 +807,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "포항시제2선거구"
+        "lang:ko": "포항시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -831,7 +831,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "상주시제2선거구"
+        "lang:ko": "상주시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -855,7 +855,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "고령군선거구"
+        "lang:ko": "고령군선거구"
       },
       "parent_id": "Q41154"
     },
@@ -879,7 +879,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "구미시제3선거구"
+        "lang:ko": "구미시제3선거구"
       },
       "parent_id": "Q41154"
     },
@@ -903,7 +903,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "구미시제4선거구"
+        "lang:ko": "구미시제4선거구"
       },
       "parent_id": "Q41154"
     },
@@ -927,7 +927,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "칠곡군제2선거구"
+        "lang:ko": "칠곡군제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -951,7 +951,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "청도군제2선거구"
+        "lang:ko": "청도군제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -975,7 +975,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "안동시제3선거구"
+        "lang:ko": "안동시제3선거구"
       },
       "parent_id": "Q41154"
     },
@@ -999,7 +999,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "포항시제8선거구"
+        "lang:ko": "포항시제8선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1023,7 +1023,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "구미시제2선거구"
+        "lang:ko": "구미시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1047,7 +1047,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "영천시제1선거구"
+        "lang:ko": "영천시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1071,7 +1071,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "영덕군선거구"
+        "lang:ko": "영덕군선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1095,7 +1095,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "예천군제2선거구"
+        "lang:ko": "예천군제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1119,7 +1119,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경산시제3선거구"
+        "lang:ko": "경산시제3선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1143,7 +1143,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경산시제2선거구"
+        "lang:ko": "경산시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1167,7 +1167,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "상주시제1선거구"
+        "lang:ko": "상주시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1191,7 +1191,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "영주시제2선거구"
+        "lang:ko": "영주시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1215,7 +1215,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "포항시제6선거구"
+        "lang:ko": "포항시제6선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1239,7 +1239,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "청도군제1선거구"
+        "lang:ko": "청도군제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1263,7 +1263,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "울진군제1선거구"
+        "lang:ko": "울진군제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1287,7 +1287,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "울릉군선거구"
+        "lang:ko": "울릉군선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1311,7 +1311,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "의성군제1선거구"
+        "lang:ko": "의성군제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1335,7 +1335,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "영천시제2선거구"
+        "lang:ko": "영천시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1359,7 +1359,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "김천시제1선거구"
+        "lang:ko": "김천시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1383,7 +1383,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "울진군제2선거구"
+        "lang:ko": "울진군제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1407,7 +1407,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경주시제1선거구"
+        "lang:ko": "경주시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1431,7 +1431,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "안동시제1선거구"
+        "lang:ko": "안동시제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1455,7 +1455,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "의성군제2선거구"
+        "lang:ko": "의성군제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1479,7 +1479,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "성주군제1선거구"
+        "lang:ko": "성주군제1선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1503,7 +1503,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "김천시제2선거구"
+        "lang:ko": "김천시제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1527,7 +1527,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "성주군제2선거구"
+        "lang:ko": "성주군제2선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1551,7 +1551,7 @@
         "lang:en": "FLACS Council Constituency of North Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경상북도 비례대표 선거구"
+        "lang:ko": "경상북도 비례대표 선거구"
       },
       "parent_id": "Q41154"
     },
@@ -1574,8 +1574,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16094335/Q50798291/popolo-m17n.json
+++ b/legislative/Q16094335/Q50798291/popolo-m17n.json
@@ -233,8 +233,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Gwangju",
-        "lang:ko_KR": "광주광역시"
+        "lang:en": "Gwangju",
+        "lang:ko": "광주광역시"
       },
       "parent_id": "Q884"
     },
@@ -258,7 +258,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "북구제1선거구"
+        "lang:ko": "북구제1선거구"
       },
       "parent_id": "Q41283"
     },
@@ -282,7 +282,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "북구제2선거구"
+        "lang:ko": "북구제2선거구"
       },
       "parent_id": "Q41283"
     },
@@ -306,7 +306,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "북구제3선거구"
+        "lang:ko": "북구제3선거구"
       },
       "parent_id": "Q41283"
     },
@@ -330,7 +330,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "북구제4선거구"
+        "lang:ko": "북구제4선거구"
       },
       "parent_id": "Q41283"
     },
@@ -354,7 +354,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "광주광역시북구제5선거구"
+        "lang:ko": "광주광역시북구제5선거구"
       },
       "parent_id": "Q41283"
     },
@@ -378,7 +378,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "동구제2선거구"
+        "lang:ko": "동구제2선거구"
       },
       "parent_id": "Q41283"
     },
@@ -402,7 +402,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "남구제1선거구"
+        "lang:ko": "남구제1선거구"
       },
       "parent_id": "Q41283"
     },
@@ -426,7 +426,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "광산구제3선거구"
+        "lang:ko": "광산구제3선거구"
       },
       "parent_id": "Q41283"
     },
@@ -450,7 +450,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "동구제1선거구"
+        "lang:ko": "동구제1선거구"
       },
       "parent_id": "Q41283"
     },
@@ -474,7 +474,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "광산구제1선거구"
+        "lang:ko": "광산구제1선거구"
       },
       "parent_id": "Q41283"
     },
@@ -498,7 +498,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "남구제3선거구"
+        "lang:ko": "남구제3선거구"
       },
       "parent_id": "Q41283"
     },
@@ -522,7 +522,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "서구제1선거구"
+        "lang:ko": "서구제1선거구"
       },
       "parent_id": "Q41283"
     },
@@ -546,7 +546,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "서구제3선거구"
+        "lang:ko": "서구제3선거구"
       },
       "parent_id": "Q41283"
     },
@@ -570,7 +570,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "서구제4선거구"
+        "lang:ko": "서구제4선거구"
       },
       "parent_id": "Q41283"
     },
@@ -594,7 +594,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "서구제2선거구"
+        "lang:ko": "서구제2선거구"
       },
       "parent_id": "Q41283"
     },
@@ -618,7 +618,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "광산구제2선거구"
+        "lang:ko": "광산구제2선거구"
       },
       "parent_id": "Q41283"
     },
@@ -642,7 +642,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "북구제6선거구"
+        "lang:ko": "북구제6선거구"
       },
       "parent_id": "Q41283"
     },
@@ -666,7 +666,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "남구제2선거구"
+        "lang:ko": "남구제2선거구"
       },
       "parent_id": "Q41283"
     },
@@ -690,7 +690,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "광산구제4선거구"
+        "lang:ko": "광산구제4선거구"
       },
       "parent_id": "Q41283"
     },
@@ -714,7 +714,7 @@
         "lang:en": "FLACS Council Constituency of Gwangju"
       },
       "name": {
-        "lang:ko_KR": "광주광역시 비례대표 선거구"
+        "lang:ko": "광주광역시 비례대표 선거구"
       },
       "parent_id": "Q41283"
     },
@@ -737,8 +737,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16094835/Q50798277/popolo-m17n.json
+++ b/legislative/Q16094835/Q50798277/popolo-m17n.json
@@ -224,8 +224,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gyeongsangnam-do",
-        "lang:ko_KR": "경상남도"
+        "lang:en": "Gyeongsangnam-do",
+        "lang:ko": "경상남도"
       },
       "parent_id": "Q884"
     },
@@ -249,7 +249,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "함양군선거구"
+        "lang:ko": "함양군선거구"
       },
       "parent_id": "Q41151"
     },
@@ -273,7 +273,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "진주시제4선거구"
+        "lang:ko": "진주시제4선거구"
       },
       "parent_id": "Q41151"
     },
@@ -297,7 +297,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "밀양시제2선거구"
+        "lang:ko": "밀양시제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -321,7 +321,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "양산시제1선거구"
+        "lang:ko": "양산시제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -345,7 +345,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "통영시제1선거구"
+        "lang:ko": "통영시제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -369,7 +369,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제5선거구"
+        "lang:ko": "창원시제5선거구"
       },
       "parent_id": "Q41151"
     },
@@ -393,7 +393,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창녕군제1선거구"
+        "lang:ko": "창녕군제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -417,7 +417,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "양산시제3선거구"
+        "lang:ko": "양산시제3선거구"
       },
       "parent_id": "Q41151"
     },
@@ -441,7 +441,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제11선거구"
+        "lang:ko": "창원시제11선거구"
       },
       "parent_id": "Q41151"
     },
@@ -465,7 +465,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "김해시제7선거구"
+        "lang:ko": "김해시제7선거구"
       },
       "parent_id": "Q41151"
     },
@@ -489,7 +489,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "김해시제3선거구"
+        "lang:ko": "김해시제3선거구"
       },
       "parent_id": "Q41151"
     },
@@ -513,7 +513,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "합천군선거구"
+        "lang:ko": "합천군선거구"
       },
       "parent_id": "Q41151"
     },
@@ -537,7 +537,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제10선거구"
+        "lang:ko": "창원시제10선거구"
       },
       "parent_id": "Q41151"
     },
@@ -561,7 +561,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "진주시제2선거구"
+        "lang:ko": "진주시제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -585,7 +585,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제3선거구"
+        "lang:ko": "창원시제3선거구"
       },
       "parent_id": "Q41151"
     },
@@ -609,7 +609,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "김해시제5선거구"
+        "lang:ko": "김해시제5선거구"
       },
       "parent_id": "Q41151"
     },
@@ -633,7 +633,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "거제시제3선거구"
+        "lang:ko": "거제시제3선거구"
       },
       "parent_id": "Q41151"
     },
@@ -657,7 +657,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창녕군제2선거구"
+        "lang:ko": "창녕군제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -681,7 +681,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "김해시제2선거구"
+        "lang:ko": "김해시제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -705,7 +705,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "하동군선거구"
+        "lang:ko": "하동군선거구"
       },
       "parent_id": "Q41151"
     },
@@ -729,7 +729,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "통영시제2선거구"
+        "lang:ko": "통영시제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -753,7 +753,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "김해시제1선거구"
+        "lang:ko": "김해시제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -777,7 +777,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제9선거구"
+        "lang:ko": "창원시제9선거구"
       },
       "parent_id": "Q41151"
     },
@@ -801,7 +801,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "산청군선거구"
+        "lang:ko": "산청군선거구"
       },
       "parent_id": "Q41151"
     },
@@ -825,7 +825,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제7선거구"
+        "lang:ko": "창원시제7선거구"
       },
       "parent_id": "Q41151"
     },
@@ -849,7 +849,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "거창군제1선거구"
+        "lang:ko": "거창군제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -873,7 +873,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "거제시제1선거구"
+        "lang:ko": "거제시제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -897,7 +897,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "함안군제1선거구"
+        "lang:ko": "함안군제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -921,7 +921,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "사천시제1선거구"
+        "lang:ko": "사천시제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -945,7 +945,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제4선거구"
+        "lang:ko": "창원시제4선거구"
       },
       "parent_id": "Q41151"
     },
@@ -969,7 +969,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제6선거구"
+        "lang:ko": "창원시제6선거구"
       },
       "parent_id": "Q41151"
     },
@@ -993,7 +993,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "함안군제2선거구"
+        "lang:ko": "함안군제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1017,7 +1017,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "진주시제1선거구"
+        "lang:ko": "진주시제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1041,7 +1041,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "남해군선거구"
+        "lang:ko": "남해군선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1065,7 +1065,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "거창군제2선거구"
+        "lang:ko": "거창군제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1089,7 +1089,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제12선거구"
+        "lang:ko": "창원시제12선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1113,7 +1113,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "고성군제2선거구"
+        "lang:ko": "고성군제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1137,7 +1137,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "양산시제2선거구"
+        "lang:ko": "양산시제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1161,7 +1161,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제1선거구"
+        "lang:ko": "창원시제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1185,7 +1185,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "거제시제2선거구"
+        "lang:ko": "거제시제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1209,7 +1209,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "밀양시제1선거구"
+        "lang:ko": "밀양시제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1233,7 +1233,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "진주시제3선거구"
+        "lang:ko": "진주시제3선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1257,7 +1257,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "김해시제6선거구"
+        "lang:ko": "김해시제6선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1281,7 +1281,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제8선거구"
+        "lang:ko": "창원시제8선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1305,7 +1305,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "사천시제2선거구"
+        "lang:ko": "사천시제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1329,7 +1329,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제13선거구"
+        "lang:ko": "창원시제13선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1353,7 +1353,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "고성군제1선거구"
+        "lang:ko": "고성군제1선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1377,7 +1377,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "김해시제4선거구"
+        "lang:ko": "김해시제4선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1401,7 +1401,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "의령군선거구"
+        "lang:ko": "의령군선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1425,7 +1425,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "창원시제2선거구"
+        "lang:ko": "창원시제2선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1449,7 +1449,7 @@
         "lang:en": "FLACS Council Constituency of South Gyeongsang Province"
       },
       "name": {
-        "lang:ko_KR": "경상남도 비례대표 선거구"
+        "lang:ko": "경상남도 비례대표 선거구"
       },
       "parent_id": "Q41151"
     },
@@ -1472,8 +1472,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16095349/Q50798372/popolo-m17n.json
+++ b/legislative/Q16095349/Q50798372/popolo-m17n.json
@@ -236,8 +236,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Daegu",
-        "lang:ko_KR": "대구광역시"
+        "lang:en": "Daegu",
+        "lang:ko": "대구광역시"
       },
       "parent_id": "Q884"
     },
@@ -261,7 +261,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "수성구제2선거구"
+        "lang:ko": "수성구제2선거구"
       },
       "parent_id": "Q20927"
     },
@@ -285,7 +285,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "달서구제4선거구"
+        "lang:ko": "달서구제4선거구"
       },
       "parent_id": "Q20927"
     },
@@ -309,7 +309,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "수성구제1선거구"
+        "lang:ko": "수성구제1선거구"
       },
       "parent_id": "Q20927"
     },
@@ -333,7 +333,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "중구제1선거구"
+        "lang:ko": "중구제1선거구"
       },
       "parent_id": "Q20927"
     },
@@ -357,7 +357,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "북구제3선거구"
+        "lang:ko": "북구제3선거구"
       },
       "parent_id": "Q20927"
     },
@@ -381,7 +381,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "수성구제3선거구"
+        "lang:ko": "수성구제3선거구"
       },
       "parent_id": "Q20927"
     },
@@ -405,7 +405,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "수성구제4선거구"
+        "lang:ko": "수성구제4선거구"
       },
       "parent_id": "Q20927"
     },
@@ -429,7 +429,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "달서구제6선거구"
+        "lang:ko": "달서구제6선거구"
       },
       "parent_id": "Q20927"
     },
@@ -453,7 +453,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "동구제1선거구"
+        "lang:ko": "동구제1선거구"
       },
       "parent_id": "Q20927"
     },
@@ -477,7 +477,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "달서구제1선거구"
+        "lang:ko": "달서구제1선거구"
       },
       "parent_id": "Q20927"
     },
@@ -501,7 +501,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "북구제4선거구"
+        "lang:ko": "북구제4선거구"
       },
       "parent_id": "Q20927"
     },
@@ -525,7 +525,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "중구제2선거구"
+        "lang:ko": "중구제2선거구"
       },
       "parent_id": "Q20927"
     },
@@ -549,7 +549,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "동구제2선거구"
+        "lang:ko": "동구제2선거구"
       },
       "parent_id": "Q20927"
     },
@@ -573,7 +573,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "남구제1선거구"
+        "lang:ko": "남구제1선거구"
       },
       "parent_id": "Q20927"
     },
@@ -597,7 +597,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "북구제1선거구"
+        "lang:ko": "북구제1선거구"
       },
       "parent_id": "Q20927"
     },
@@ -621,7 +621,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "달서구제2선거구"
+        "lang:ko": "달서구제2선거구"
       },
       "parent_id": "Q20927"
     },
@@ -645,7 +645,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "서구제2선거구"
+        "lang:ko": "서구제2선거구"
       },
       "parent_id": "Q20927"
     },
@@ -669,7 +669,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "달서구제3선거구"
+        "lang:ko": "달서구제3선거구"
       },
       "parent_id": "Q20927"
     },
@@ -693,7 +693,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "북구제5선거구"
+        "lang:ko": "북구제5선거구"
       },
       "parent_id": "Q20927"
     },
@@ -717,7 +717,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "동구제4선거구"
+        "lang:ko": "동구제4선거구"
       },
       "parent_id": "Q20927"
     },
@@ -741,7 +741,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "서구제1선거구"
+        "lang:ko": "서구제1선거구"
       },
       "parent_id": "Q20927"
     },
@@ -765,7 +765,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "달성군제2선거구"
+        "lang:ko": "달성군제2선거구"
       },
       "parent_id": "Q20927"
     },
@@ -789,7 +789,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "달서구제5선거구"
+        "lang:ko": "달서구제5선거구"
       },
       "parent_id": "Q20927"
     },
@@ -813,7 +813,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "달성군제1선거구"
+        "lang:ko": "달성군제1선거구"
       },
       "parent_id": "Q20927"
     },
@@ -837,7 +837,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "북구제2선거구"
+        "lang:ko": "북구제2선거구"
       },
       "parent_id": "Q20927"
     },
@@ -861,7 +861,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "동구제3선거구"
+        "lang:ko": "동구제3선거구"
       },
       "parent_id": "Q20927"
     },
@@ -885,7 +885,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "남구제2선거구"
+        "lang:ko": "남구제2선거구"
       },
       "parent_id": "Q20927"
     },
@@ -909,7 +909,7 @@
         "lang:en": "FLACS Council Constituency of Daegu"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 비례대표 선거구"
+        "lang:ko": "대구광역시 비례대표 선거구"
       },
       "parent_id": "Q20927"
     },
@@ -932,8 +932,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16095510/Q50797896/popolo-m17n.json
+++ b/legislative/Q16095510/Q50797896/popolo-m17n.json
@@ -252,8 +252,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Daejeon",
-        "lang:ko_KR": "대전광역시"
+        "lang:en": "Daejeon",
+        "lang:ko": "대전광역시"
       },
       "parent_id": "Q884"
     },
@@ -277,7 +277,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "동구제2선거구"
+        "lang:ko": "동구제2선거구"
       },
       "parent_id": "Q20921"
     },
@@ -301,7 +301,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "중구제1선거구"
+        "lang:ko": "중구제1선거구"
       },
       "parent_id": "Q20921"
     },
@@ -325,7 +325,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "서구제6선거구"
+        "lang:ko": "서구제6선거구"
       },
       "parent_id": "Q20921"
     },
@@ -349,7 +349,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "대덕구제3선거구"
+        "lang:ko": "대덕구제3선거구"
       },
       "parent_id": "Q20921"
     },
@@ -373,7 +373,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "유성구제1선거구"
+        "lang:ko": "유성구제1선거구"
       },
       "parent_id": "Q20921"
     },
@@ -397,7 +397,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "유성구제2선거구"
+        "lang:ko": "유성구제2선거구"
       },
       "parent_id": "Q20921"
     },
@@ -421,7 +421,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "서구제2선거구"
+        "lang:ko": "서구제2선거구"
       },
       "parent_id": "Q20921"
     },
@@ -445,7 +445,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "대덕구제2선거구"
+        "lang:ko": "대덕구제2선거구"
       },
       "parent_id": "Q20921"
     },
@@ -469,7 +469,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "동구제1선거구"
+        "lang:ko": "동구제1선거구"
       },
       "parent_id": "Q20921"
     },
@@ -493,7 +493,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "중구제3선거구"
+        "lang:ko": "중구제3선거구"
       },
       "parent_id": "Q20921"
     },
@@ -517,7 +517,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "동구제3선거구"
+        "lang:ko": "동구제3선거구"
       },
       "parent_id": "Q20921"
     },
@@ -541,7 +541,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "서구제1선거구"
+        "lang:ko": "서구제1선거구"
       },
       "parent_id": "Q20921"
     },
@@ -565,7 +565,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "서구제3선거구"
+        "lang:ko": "서구제3선거구"
       },
       "parent_id": "Q20921"
     },
@@ -589,7 +589,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "대덕구제1선거구"
+        "lang:ko": "대덕구제1선거구"
       },
       "parent_id": "Q20921"
     },
@@ -613,7 +613,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "유성구제3선거구"
+        "lang:ko": "유성구제3선거구"
       },
       "parent_id": "Q20921"
     },
@@ -637,7 +637,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "유성구제4선거구"
+        "lang:ko": "유성구제4선거구"
       },
       "parent_id": "Q20921"
     },
@@ -661,7 +661,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "서구제5선거구"
+        "lang:ko": "서구제5선거구"
       },
       "parent_id": "Q20921"
     },
@@ -685,7 +685,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "서구제4선거구"
+        "lang:ko": "서구제4선거구"
       },
       "parent_id": "Q20921"
     },
@@ -709,7 +709,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "중구제2선거구"
+        "lang:ko": "중구제2선거구"
       },
       "parent_id": "Q20921"
     },
@@ -733,7 +733,7 @@
         "lang:en": "FLACS Council Constituency of Daejeon"
       },
       "name": {
-        "lang:ko_KR": "대전광역시 비례대표 선거구"
+        "lang:ko": "대전광역시 비례대표 선거구"
       },
       "parent_id": "Q20921"
     },
@@ -756,8 +756,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16096697/Q50798199/popolo-m17n.json
+++ b/legislative/Q16096697/Q50798199/popolo-m17n.json
@@ -233,8 +233,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Busan",
-        "lang:ko_KR": "부산광역시"
+        "lang:en": "Busan",
+        "lang:ko": "부산광역시"
       },
       "parent_id": "Q884"
     },
@@ -258,7 +258,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "동구제2선거구"
+        "lang:ko": "동구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -282,7 +282,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "동래구제3선거구"
+        "lang:ko": "동래구제3선거구"
       },
       "parent_id": "Q16520"
     },
@@ -306,7 +306,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "해운대구제4선거구"
+        "lang:ko": "해운대구제4선거구"
       },
       "parent_id": "Q16520"
     },
@@ -330,7 +330,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "남구제1선거구"
+        "lang:ko": "남구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -354,7 +354,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "북구제3선거구"
+        "lang:ko": "북구제3선거구"
       },
       "parent_id": "Q16520"
     },
@@ -378,7 +378,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "사하구제2선거구"
+        "lang:ko": "사하구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -402,7 +402,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "금정구제2선거구"
+        "lang:ko": "금정구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -426,7 +426,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "수영구제2선거구"
+        "lang:ko": "수영구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -450,7 +450,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "연제구제2선거구"
+        "lang:ko": "연제구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -474,7 +474,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "강서구제1선거구"
+        "lang:ko": "강서구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -498,7 +498,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "동래구제1선거구"
+        "lang:ko": "동래구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -522,7 +522,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "기장군제1선거구"
+        "lang:ko": "기장군제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -546,7 +546,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "동구제1선거구"
+        "lang:ko": "동구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -570,7 +570,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "사상구제1선거구"
+        "lang:ko": "사상구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -594,7 +594,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "북구제4선거구"
+        "lang:ko": "북구제4선거구"
       },
       "parent_id": "Q16520"
     },
@@ -618,7 +618,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "사하구제4선거구"
+        "lang:ko": "사하구제4선거구"
       },
       "parent_id": "Q16520"
     },
@@ -642,7 +642,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "영도구제1선거구"
+        "lang:ko": "영도구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -666,7 +666,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "남구제2선거구"
+        "lang:ko": "남구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -690,7 +690,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "해운대구제2선거구"
+        "lang:ko": "해운대구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -714,7 +714,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "부산진구제4선거구"
+        "lang:ko": "부산진구제4선거구"
       },
       "parent_id": "Q16520"
     },
@@ -738,7 +738,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "북구제1선거구"
+        "lang:ko": "북구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -762,7 +762,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "영도구제2선거구"
+        "lang:ko": "영도구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -786,7 +786,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "기장군제2선거구"
+        "lang:ko": "기장군제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -810,7 +810,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "부산진구제1선거구"
+        "lang:ko": "부산진구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -834,7 +834,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "사하구제3선거구"
+        "lang:ko": "사하구제3선거구"
       },
       "parent_id": "Q16520"
     },
@@ -858,7 +858,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "서구제2선거구"
+        "lang:ko": "서구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -882,7 +882,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "남구제4선거구"
+        "lang:ko": "남구제4선거구"
       },
       "parent_id": "Q16520"
     },
@@ -906,7 +906,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "부산진구제2선거구"
+        "lang:ko": "부산진구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -930,7 +930,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "중구선거구"
+        "lang:ko": "중구선거구"
       },
       "parent_id": "Q16520"
     },
@@ -954,7 +954,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "남구제3선거구"
+        "lang:ko": "남구제3선거구"
       },
       "parent_id": "Q16520"
     },
@@ -978,7 +978,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "수영구제1선거구"
+        "lang:ko": "수영구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1002,7 +1002,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "동래구제2선거구"
+        "lang:ko": "동래구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1026,7 +1026,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "서구제1선거구"
+        "lang:ko": "서구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1050,7 +1050,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "해운대구제1선거구"
+        "lang:ko": "해운대구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1074,7 +1074,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "강서구제2선거구"
+        "lang:ko": "강서구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1098,7 +1098,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "해운대구제3선거구"
+        "lang:ko": "해운대구제3선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1122,7 +1122,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "부산진구제3선거구"
+        "lang:ko": "부산진구제3선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1146,7 +1146,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "연제구제1선거구"
+        "lang:ko": "연제구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1170,7 +1170,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "사하구제1선거구"
+        "lang:ko": "사하구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1194,7 +1194,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "북구제2선거구"
+        "lang:ko": "북구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1218,7 +1218,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "사상구제2선거구"
+        "lang:ko": "사상구제2선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1242,7 +1242,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "금정구제1선거구"
+        "lang:ko": "금정구제1선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1266,7 +1266,7 @@
         "lang:en": "FLACS Council Constituency of Busan"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 비례대표 선거구"
+        "lang:ko": "부산광역시 비례대표 선거구"
       },
       "parent_id": "Q16520"
     },
@@ -1289,8 +1289,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16097908/Q50798215/popolo-m17n.json
+++ b/legislative/Q16097908/Q50798215/popolo-m17n.json
@@ -244,8 +244,8 @@
         "lang:en": "special autonomous city in South Korea"
       },
       "name": {
-        "lang:en_US": "Sejong Special Self-Governing City",
-        "lang:ko_KR": "세종특별자치시"
+        "lang:en": "Sejong Special Self-Governing City",
+        "lang:ko": "세종특별자치시"
       },
       "parent_id": "Q884"
     },
@@ -269,7 +269,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제13선거구"
+        "lang:ko": "세종특별자치시제13선거구"
       },
       "parent_id": "Q20929"
     },
@@ -293,7 +293,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제9선거구"
+        "lang:ko": "세종특별자치시제9선거구"
       },
       "parent_id": "Q20929"
     },
@@ -317,7 +317,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제4선거구"
+        "lang:ko": "세종특별자치시제4선거구"
       },
       "parent_id": "Q20929"
     },
@@ -341,7 +341,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제2선거구"
+        "lang:ko": "세종특별자치시제2선거구"
       },
       "parent_id": "Q20929"
     },
@@ -365,7 +365,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제11선거구"
+        "lang:ko": "세종특별자치시제11선거구"
       },
       "parent_id": "Q20929"
     },
@@ -389,7 +389,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제7선거구"
+        "lang:ko": "세종특별자치시제7선거구"
       },
       "parent_id": "Q20929"
     },
@@ -413,7 +413,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제5선거구"
+        "lang:ko": "세종특별자치시제5선거구"
       },
       "parent_id": "Q20929"
     },
@@ -437,7 +437,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제8선거구"
+        "lang:ko": "세종특별자치시제8선거구"
       },
       "parent_id": "Q20929"
     },
@@ -461,7 +461,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제6선거구"
+        "lang:ko": "세종특별자치시제6선거구"
       },
       "parent_id": "Q20929"
     },
@@ -485,7 +485,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제1선거구"
+        "lang:ko": "세종특별자치시제1선거구"
       },
       "parent_id": "Q20929"
     },
@@ -509,7 +509,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제3선거구"
+        "lang:ko": "세종특별자치시제3선거구"
       },
       "parent_id": "Q20929"
     },
@@ -533,7 +533,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제10선거구"
+        "lang:ko": "세종특별자치시제10선거구"
       },
       "parent_id": "Q20929"
     },
@@ -557,7 +557,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시제12선거구"
+        "lang:ko": "세종특별자치시제12선거구"
       },
       "parent_id": "Q20929"
     },
@@ -581,7 +581,7 @@
         "lang:en": "FLACS Council Constituency of Sejong City"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시 비례대표 선거구"
+        "lang:ko": "세종특별자치시 비례대표 선거구"
       },
       "parent_id": "Q20929"
     },
@@ -604,8 +604,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16099049/Q50798406/popolo-m17n.json
+++ b/legislative/Q16099049/Q50798406/popolo-m17n.json
@@ -245,8 +245,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Ulsan",
-        "lang:ko_KR": "울산광역시"
+        "lang:en": "Ulsan",
+        "lang:ko": "울산광역시"
       },
       "parent_id": "Q884"
     },
@@ -270,7 +270,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "동구제2선거구"
+        "lang:ko": "동구제2선거구"
       },
       "parent_id": "Q41278"
     },
@@ -294,7 +294,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "남구제1선거구"
+        "lang:ko": "남구제1선거구"
       },
       "parent_id": "Q41278"
     },
@@ -318,7 +318,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "북구제1선거구"
+        "lang:ko": "북구제1선거구"
       },
       "parent_id": "Q41278"
     },
@@ -342,7 +342,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "남구제5선거구"
+        "lang:ko": "남구제5선거구"
       },
       "parent_id": "Q41278"
     },
@@ -366,7 +366,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "중구제1선거구"
+        "lang:ko": "중구제1선거구"
       },
       "parent_id": "Q41278"
     },
@@ -390,7 +390,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "북구제3선거구"
+        "lang:ko": "북구제3선거구"
       },
       "parent_id": "Q41278"
     },
@@ -414,7 +414,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "중구제3선거구"
+        "lang:ko": "중구제3선거구"
       },
       "parent_id": "Q41278"
     },
@@ -438,7 +438,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "중구제4선거구"
+        "lang:ko": "중구제4선거구"
       },
       "parent_id": "Q41278"
     },
@@ -462,7 +462,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "남구제6선거구"
+        "lang:ko": "남구제6선거구"
       },
       "parent_id": "Q41278"
     },
@@ -486,7 +486,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "동구제3선거구"
+        "lang:ko": "동구제3선거구"
       },
       "parent_id": "Q41278"
     },
@@ -510,7 +510,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "울주군제2선거구"
+        "lang:ko": "울주군제2선거구"
       },
       "parent_id": "Q41278"
     },
@@ -534,7 +534,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "남구제3선거구"
+        "lang:ko": "남구제3선거구"
       },
       "parent_id": "Q41278"
     },
@@ -558,7 +558,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "동구제1선거구"
+        "lang:ko": "동구제1선거구"
       },
       "parent_id": "Q41278"
     },
@@ -582,7 +582,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "울주군제3선거구"
+        "lang:ko": "울주군제3선거구"
       },
       "parent_id": "Q41278"
     },
@@ -606,7 +606,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "남구제4선거구"
+        "lang:ko": "남구제4선거구"
       },
       "parent_id": "Q41278"
     },
@@ -630,7 +630,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "북구제2선거구"
+        "lang:ko": "북구제2선거구"
       },
       "parent_id": "Q41278"
     },
@@ -654,7 +654,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "울주군제1선거구"
+        "lang:ko": "울주군제1선거구"
       },
       "parent_id": "Q41278"
     },
@@ -678,7 +678,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "남구제2선거구"
+        "lang:ko": "남구제2선거구"
       },
       "parent_id": "Q41278"
     },
@@ -702,7 +702,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "중구제2선거구"
+        "lang:ko": "중구제2선거구"
       },
       "parent_id": "Q41278"
     },
@@ -726,7 +726,7 @@
         "lang:en": "FLACS Council Constituency of Ulsan"
       },
       "name": {
-        "lang:ko_KR": "울산광역시 비례대표 선거구"
+        "lang:ko": "울산광역시 비례대표 선거구"
       },
       "parent_id": "Q41278"
     },
@@ -749,8 +749,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16099448/Q50798182/popolo-m17n.json
+++ b/legislative/Q16099448/Q50798182/popolo-m17n.json
@@ -247,8 +247,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Incheon",
-        "lang:ko_KR": "인천광역시"
+        "lang:en": "Incheon",
+        "lang:ko": "인천광역시"
       },
       "parent_id": "Q884"
     },
@@ -272,7 +272,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "계양구제4선거구"
+        "lang:ko": "계양구제4선거구"
       },
       "parent_id": "Q20934"
     },
@@ -296,7 +296,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "부평구제4선거구"
+        "lang:ko": "부평구제4선거구"
       },
       "parent_id": "Q20934"
     },
@@ -320,7 +320,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "동구제2선거구"
+        "lang:ko": "동구제2선거구"
       },
       "parent_id": "Q20934"
     },
@@ -344,7 +344,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "중구제1선거구"
+        "lang:ko": "중구제1선거구"
       },
       "parent_id": "Q20934"
     },
@@ -368,7 +368,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "남동구제5선거구"
+        "lang:ko": "남동구제5선거구"
       },
       "parent_id": "Q20934"
     },
@@ -392,7 +392,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "부평구제2선거구"
+        "lang:ko": "부평구제2선거구"
       },
       "parent_id": "Q20934"
     },
@@ -416,7 +416,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "계양구제1선거구"
+        "lang:ko": "계양구제1선거구"
       },
       "parent_id": "Q20934"
     },
@@ -440,7 +440,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "남구제4선거구"
+        "lang:ko": "남구제4선거구"
       },
       "parent_id": "Q20934"
     },
@@ -464,7 +464,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "부평구제5선거구"
+        "lang:ko": "부평구제5선거구"
       },
       "parent_id": "Q20934"
     },
@@ -488,7 +488,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "서구제3선거구"
+        "lang:ko": "서구제3선거구"
       },
       "parent_id": "Q20934"
     },
@@ -512,7 +512,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "남동구제2선거구"
+        "lang:ko": "남동구제2선거구"
       },
       "parent_id": "Q20934"
     },
@@ -536,7 +536,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "연수구제2선거구"
+        "lang:ko": "연수구제2선거구"
       },
       "parent_id": "Q20934"
     },
@@ -560,7 +560,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "동구제1선거구"
+        "lang:ko": "동구제1선거구"
       },
       "parent_id": "Q20934"
     },
@@ -584,7 +584,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "강화군선거구"
+        "lang:ko": "강화군선거구"
       },
       "parent_id": "Q20934"
     },
@@ -608,7 +608,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "남구제3선거구"
+        "lang:ko": "남구제3선거구"
       },
       "parent_id": "Q20934"
     },
@@ -632,7 +632,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "연수구제1선거구"
+        "lang:ko": "연수구제1선거구"
       },
       "parent_id": "Q20934"
     },
@@ -656,7 +656,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "옹진군선거구"
+        "lang:ko": "옹진군선거구"
       },
       "parent_id": "Q20934"
     },
@@ -680,7 +680,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "남동구제1선거구"
+        "lang:ko": "남동구제1선거구"
       },
       "parent_id": "Q20934"
     },
@@ -704,7 +704,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "남구제1선거구"
+        "lang:ko": "남구제1선거구"
       },
       "parent_id": "Q20934"
     },
@@ -728,7 +728,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "남동구제3선거구"
+        "lang:ko": "남동구제3선거구"
       },
       "parent_id": "Q20934"
     },
@@ -752,7 +752,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "중구제2선거구"
+        "lang:ko": "중구제2선거구"
       },
       "parent_id": "Q20934"
     },
@@ -776,7 +776,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "부평구제1선거구"
+        "lang:ko": "부평구제1선거구"
       },
       "parent_id": "Q20934"
     },
@@ -800,7 +800,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "부평구제3선거구"
+        "lang:ko": "부평구제3선거구"
       },
       "parent_id": "Q20934"
     },
@@ -824,7 +824,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "서구제2선거구"
+        "lang:ko": "서구제2선거구"
       },
       "parent_id": "Q20934"
     },
@@ -848,7 +848,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "서구제4선거구"
+        "lang:ko": "서구제4선거구"
       },
       "parent_id": "Q20934"
     },
@@ -872,7 +872,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "서구제1선거구"
+        "lang:ko": "서구제1선거구"
       },
       "parent_id": "Q20934"
     },
@@ -896,7 +896,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "계양구제2선거구"
+        "lang:ko": "계양구제2선거구"
       },
       "parent_id": "Q20934"
     },
@@ -920,7 +920,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "남동구제4선거구"
+        "lang:ko": "남동구제4선거구"
       },
       "parent_id": "Q20934"
     },
@@ -944,7 +944,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "연수구제3선거구"
+        "lang:ko": "연수구제3선거구"
       },
       "parent_id": "Q20934"
     },
@@ -968,7 +968,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "계양구제3선거구"
+        "lang:ko": "계양구제3선거구"
       },
       "parent_id": "Q20934"
     },
@@ -992,7 +992,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "남구제2선거구"
+        "lang:ko": "남구제2선거구"
       },
       "parent_id": "Q20934"
     },
@@ -1016,7 +1016,7 @@
         "lang:en": "FLACS Council Constituency of Incheon"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 비례대표 선거구"
+        "lang:ko": "인천광역시 비례대표 선거구"
       },
       "parent_id": "Q20934"
     },
@@ -1039,8 +1039,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16099669/Q50798313/popolo-m17n.json
+++ b/legislative/Q16099669/Q50798313/popolo-m17n.json
@@ -235,8 +235,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Jeollanam-do",
-        "lang:ko_KR": "전라남도"
+        "lang:en": "Jeollanam-do",
+        "lang:ko": "전라남도"
       },
       "parent_id": "Q884"
     },
@@ -260,7 +260,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "장흥군제1선거구"
+        "lang:ko": "장흥군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -284,7 +284,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "영광군제1선거구"
+        "lang:ko": "영광군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -308,7 +308,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "광양시제2선거구"
+        "lang:ko": "광양시제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -332,7 +332,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "장성군제1선거구"
+        "lang:ko": "장성군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -356,7 +356,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "목포시제1선거구"
+        "lang:ko": "목포시제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -380,7 +380,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "광양시제3선거구"
+        "lang:ko": "광양시제3선거구"
       },
       "parent_id": "Q41161"
     },
@@ -404,7 +404,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "화순군제1선거구"
+        "lang:ko": "화순군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -428,7 +428,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "목포시제3선거구"
+        "lang:ko": "목포시제3선거구"
       },
       "parent_id": "Q41161"
     },
@@ -452,7 +452,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "나주시제2선거구"
+        "lang:ko": "나주시제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -476,7 +476,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "여수시제1선거구"
+        "lang:ko": "여수시제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -500,7 +500,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "장흥군제2선거구"
+        "lang:ko": "장흥군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -524,7 +524,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "영광군제2선거구"
+        "lang:ko": "영광군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -548,7 +548,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "신안군제1선거구"
+        "lang:ko": "신안군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -572,7 +572,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "목포시제5선거구"
+        "lang:ko": "목포시제5선거구"
       },
       "parent_id": "Q41161"
     },
@@ -596,7 +596,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "화순군제2선거구"
+        "lang:ko": "화순군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -620,7 +620,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "여수시제2선거구"
+        "lang:ko": "여수시제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -644,7 +644,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "보성군제2선거구"
+        "lang:ko": "보성군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -668,7 +668,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "함평군제1선거구"
+        "lang:ko": "함평군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -692,7 +692,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "순천시제2선거구"
+        "lang:ko": "순천시제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -716,7 +716,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "순천시제3선거구"
+        "lang:ko": "순천시제3선거구"
       },
       "parent_id": "Q41161"
     },
@@ -740,7 +740,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "함평군제2선거구"
+        "lang:ko": "함평군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -764,7 +764,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "곡성군선거구"
+        "lang:ko": "곡성군선거구"
       },
       "parent_id": "Q41161"
     },
@@ -788,7 +788,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "목포시제4선거구"
+        "lang:ko": "목포시제4선거구"
       },
       "parent_id": "Q41161"
     },
@@ -812,7 +812,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "해남군제2선거구"
+        "lang:ko": "해남군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -836,7 +836,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "고흥군제1선거구"
+        "lang:ko": "고흥군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -860,7 +860,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "여수시제4선거구"
+        "lang:ko": "여수시제4선거구"
       },
       "parent_id": "Q41161"
     },
@@ -884,7 +884,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "신안군제2선거구"
+        "lang:ko": "신안군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -908,7 +908,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "무안군제2선거구"
+        "lang:ko": "무안군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -932,7 +932,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "무안군제1선거구"
+        "lang:ko": "무안군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -956,7 +956,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "여수시제6선거구"
+        "lang:ko": "여수시제6선거구"
       },
       "parent_id": "Q41161"
     },
@@ -980,7 +980,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "진도군선거구"
+        "lang:ko": "진도군선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1004,7 +1004,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "완도군제1선거구"
+        "lang:ko": "완도군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1028,7 +1028,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "구례군선거구"
+        "lang:ko": "구례군선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1052,7 +1052,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "여수시제5선거구"
+        "lang:ko": "여수시제5선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1076,7 +1076,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "담양군제2선거구"
+        "lang:ko": "담양군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1100,7 +1100,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "해남군제1선거구"
+        "lang:ko": "해남군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1124,7 +1124,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "순천시제1선거구"
+        "lang:ko": "순천시제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1148,7 +1148,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "순천시제5선거구"
+        "lang:ko": "순천시제5선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1172,7 +1172,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "강진군제1선거구"
+        "lang:ko": "강진군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1196,7 +1196,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "담양군제1선거구"
+        "lang:ko": "담양군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1220,7 +1220,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "영암군제1선거구"
+        "lang:ko": "영암군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1244,7 +1244,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "나주시제1선거구"
+        "lang:ko": "나주시제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1268,7 +1268,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "여수시제3선거구"
+        "lang:ko": "여수시제3선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1292,7 +1292,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "강진군제2선거구"
+        "lang:ko": "강진군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1316,7 +1316,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "목포시제2선거구"
+        "lang:ko": "목포시제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1340,7 +1340,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "보성군제1선거구"
+        "lang:ko": "보성군제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1364,7 +1364,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "영암군제2선거구"
+        "lang:ko": "영암군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1388,7 +1388,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "장성군제2선거구"
+        "lang:ko": "장성군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1412,7 +1412,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "고흥군제2선거구"
+        "lang:ko": "고흥군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1436,7 +1436,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "광양시제1선거구"
+        "lang:ko": "광양시제1선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1460,7 +1460,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "순천시제4선거구"
+        "lang:ko": "순천시제4선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1484,7 +1484,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "완도군제2선거구"
+        "lang:ko": "완도군제2선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1508,7 +1508,7 @@
         "lang:en": "FLACS Council Constituency of South Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전라남도 비례대표 선거구"
+        "lang:ko": "전라남도 비례대표 선거구"
       },
       "parent_id": "Q41161"
     },
@@ -1531,8 +1531,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16100275/Q50798329/popolo-m17n.json
+++ b/legislative/Q16100275/Q50798329/popolo-m17n.json
@@ -235,8 +235,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Chungcheongnam-do",
-        "lang:ko_KR": "충청남도"
+        "lang:en": "Chungcheongnam-do",
+        "lang:ko": "충청남도"
       },
       "parent_id": "Q884"
     },
@@ -260,7 +260,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청양군선거구"
+        "lang:ko": "청양군선거구"
       },
       "parent_id": "Q41070"
     },
@@ -284,7 +284,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "천안시제2선거구"
+        "lang:ko": "천안시제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -308,7 +308,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "천안시제5선거구"
+        "lang:ko": "천안시제5선거구"
       },
       "parent_id": "Q41070"
     },
@@ -332,7 +332,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "서산시제2선거구"
+        "lang:ko": "서산시제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -356,7 +356,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "천안시제4선거구"
+        "lang:ko": "천안시제4선거구"
       },
       "parent_id": "Q41070"
     },
@@ -380,7 +380,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "서천군제1선거구"
+        "lang:ko": "서천군제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -404,7 +404,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "천안시제6선거구"
+        "lang:ko": "천안시제6선거구"
       },
       "parent_id": "Q41070"
     },
@@ -428,7 +428,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "예산군제2선거구"
+        "lang:ko": "예산군제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -452,7 +452,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "계룡시선거구"
+        "lang:ko": "계룡시선거구"
       },
       "parent_id": "Q41070"
     },
@@ -476,7 +476,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "부여군제1선거구"
+        "lang:ko": "부여군제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -500,7 +500,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "금산군제2선거구"
+        "lang:ko": "금산군제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -524,7 +524,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "천안시제7선거구"
+        "lang:ko": "천안시제7선거구"
       },
       "parent_id": "Q41070"
     },
@@ -548,7 +548,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "보령시제2선거구"
+        "lang:ko": "보령시제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -572,7 +572,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "공주시제2선거구"
+        "lang:ko": "공주시제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -596,7 +596,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "부여군제2선거구"
+        "lang:ko": "부여군제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -620,7 +620,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "천안시제8선거구"
+        "lang:ko": "천안시제8선거구"
       },
       "parent_id": "Q41070"
     },
@@ -644,7 +644,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "태안군제1선거구"
+        "lang:ko": "태안군제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -668,7 +668,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "공주시제1선거구"
+        "lang:ko": "공주시제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -692,7 +692,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "아산시제3선거구"
+        "lang:ko": "아산시제3선거구"
       },
       "parent_id": "Q41070"
     },
@@ -716,7 +716,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "아산시제4선거구"
+        "lang:ko": "아산시제4선거구"
       },
       "parent_id": "Q41070"
     },
@@ -740,7 +740,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "홍성군제1선거구"
+        "lang:ko": "홍성군제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -764,7 +764,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "보령시제1선거구"
+        "lang:ko": "보령시제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -788,7 +788,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "천안시제1선거구"
+        "lang:ko": "천안시제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -812,7 +812,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "아산시제1선거구"
+        "lang:ko": "아산시제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -836,7 +836,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "논산시제1선거구"
+        "lang:ko": "논산시제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -860,7 +860,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "당진시제1선거구"
+        "lang:ko": "당진시제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -884,7 +884,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "천안시제3선거구"
+        "lang:ko": "천안시제3선거구"
       },
       "parent_id": "Q41070"
     },
@@ -908,7 +908,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "예산군제1선거구"
+        "lang:ko": "예산군제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -932,7 +932,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "당진시제2선거구"
+        "lang:ko": "당진시제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -956,7 +956,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "서천군제2선거구"
+        "lang:ko": "서천군제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -980,7 +980,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "홍성군제2선거구"
+        "lang:ko": "홍성군제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -1004,7 +1004,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "아산시제2선거구"
+        "lang:ko": "아산시제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -1028,7 +1028,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "태안군제2선거구"
+        "lang:ko": "태안군제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -1052,7 +1052,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "서산시제1선거구"
+        "lang:ko": "서산시제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -1076,7 +1076,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "금산군제1선거구"
+        "lang:ko": "금산군제1선거구"
       },
       "parent_id": "Q41070"
     },
@@ -1100,7 +1100,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "논산시제2선거구"
+        "lang:ko": "논산시제2선거구"
       },
       "parent_id": "Q41070"
     },
@@ -1124,7 +1124,7 @@
         "lang:en": "FLACS Council Constituency of South Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "충청남도 비례대표 선거구"
+        "lang:ko": "충청남도 비례대표 선거구"
       },
       "parent_id": "Q41070"
     },
@@ -1147,8 +1147,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16100304/Q50798260/popolo-m17n.json
+++ b/legislative/Q16100304/Q50798260/popolo-m17n.json
@@ -236,8 +236,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Chungcheongbuk-do",
-        "lang:ko_KR": "충청북도"
+        "lang:en": "Chungcheongbuk-do",
+        "lang:ko": "충청북도"
       },
       "parent_id": "Q884"
     },
@@ -261,7 +261,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제2선거구"
+        "lang:ko": "청주시제2선거구"
       },
       "parent_id": "Q41066"
     },
@@ -285,7 +285,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "옥천군제1선거구"
+        "lang:ko": "옥천군제1선거구"
       },
       "parent_id": "Q41066"
     },
@@ -309,7 +309,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "괴산군선거구"
+        "lang:ko": "괴산군선거구"
       },
       "parent_id": "Q41066"
     },
@@ -333,7 +333,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제1선거구"
+        "lang:ko": "청주시제1선거구"
       },
       "parent_id": "Q41066"
     },
@@ -357,7 +357,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "증평군선거구"
+        "lang:ko": "증평군선거구"
       },
       "parent_id": "Q41066"
     },
@@ -381,7 +381,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "충주시제2선거구"
+        "lang:ko": "충주시제2선거구"
       },
       "parent_id": "Q41066"
     },
@@ -405,7 +405,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "충주시제1선거구"
+        "lang:ko": "충주시제1선거구"
       },
       "parent_id": "Q41066"
     },
@@ -429,7 +429,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "진천군제2선거구"
+        "lang:ko": "진천군제2선거구"
       },
       "parent_id": "Q41066"
     },
@@ -453,7 +453,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제9선거구"
+        "lang:ko": "청주시제9선거구"
       },
       "parent_id": "Q41066"
     },
@@ -477,7 +477,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "영동군제2선거구"
+        "lang:ko": "영동군제2선거구"
       },
       "parent_id": "Q41066"
     },
@@ -501,7 +501,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제3선거구"
+        "lang:ko": "청주시제3선거구"
       },
       "parent_id": "Q41066"
     },
@@ -525,7 +525,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "진천군제1선거구"
+        "lang:ko": "진천군제1선거구"
       },
       "parent_id": "Q41066"
     },
@@ -549,7 +549,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "단양군선거구"
+        "lang:ko": "단양군선거구"
       },
       "parent_id": "Q41066"
     },
@@ -573,7 +573,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "음성군제1선거구"
+        "lang:ko": "음성군제1선거구"
       },
       "parent_id": "Q41066"
     },
@@ -597,7 +597,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제10선거구"
+        "lang:ko": "청주시제10선거구"
       },
       "parent_id": "Q41066"
     },
@@ -621,7 +621,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제6선거구"
+        "lang:ko": "청주시제6선거구"
       },
       "parent_id": "Q41066"
     },
@@ -645,7 +645,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제8선거구"
+        "lang:ko": "청주시제8선거구"
       },
       "parent_id": "Q41066"
     },
@@ -669,7 +669,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제11선거구"
+        "lang:ko": "청주시제11선거구"
       },
       "parent_id": "Q41066"
     },
@@ -693,7 +693,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제4선거구"
+        "lang:ko": "청주시제4선거구"
       },
       "parent_id": "Q41066"
     },
@@ -717,7 +717,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "제천시제2선거구"
+        "lang:ko": "제천시제2선거구"
       },
       "parent_id": "Q41066"
     },
@@ -741,7 +741,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "음성군제2선거구"
+        "lang:ko": "음성군제2선거구"
       },
       "parent_id": "Q41066"
     },
@@ -765,7 +765,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "영동군제1선거구"
+        "lang:ko": "영동군제1선거구"
       },
       "parent_id": "Q41066"
     },
@@ -789,7 +789,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "충주시제3선거구"
+        "lang:ko": "충주시제3선거구"
       },
       "parent_id": "Q41066"
     },
@@ -813,7 +813,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제7선거구"
+        "lang:ko": "청주시제7선거구"
       },
       "parent_id": "Q41066"
     },
@@ -837,7 +837,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "옥천군제2선거구"
+        "lang:ko": "옥천군제2선거구"
       },
       "parent_id": "Q41066"
     },
@@ -861,7 +861,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "제천시제1선거구"
+        "lang:ko": "제천시제1선거구"
       },
       "parent_id": "Q41066"
     },
@@ -885,7 +885,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "보은군선거구"
+        "lang:ko": "보은군선거구"
       },
       "parent_id": "Q41066"
     },
@@ -909,7 +909,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "청주시제5선거구"
+        "lang:ko": "청주시제5선거구"
       },
       "parent_id": "Q41066"
     },
@@ -933,7 +933,7 @@
         "lang:en": "FLACS Council Constituency of North Chungcheong Province"
       },
       "name": {
-        "lang:ko_KR": "충청북도 비례대표 선거구"
+        "lang:ko": "충청북도 비례대표 선거구"
       },
       "parent_id": "Q41066"
     },
@@ -956,8 +956,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q16100817/Q50798465/popolo-m17n.json
+++ b/legislative/Q16100817/Q50798465/popolo-m17n.json
@@ -261,8 +261,8 @@
         "lang:en": "Special Self-governing Province of South Korea"
       },
       "name": {
-        "lang:en_US": "Jeju Special Self-Governing Province",
-        "lang:ko_KR": "제주특별자치도"
+        "lang:en": "Jeju Special Self-Governing Province",
+        "lang:ko": "제주특별자치도"
       },
       "parent_id": "Q884"
     },
@@ -286,7 +286,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제13선거구"
+        "lang:ko": "제주특별자치도제13선거구"
       },
       "parent_id": "Q41164"
     },
@@ -310,7 +310,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제19선거구"
+        "lang:ko": "제주특별자치도제19선거구"
       },
       "parent_id": "Q41164"
     },
@@ -334,7 +334,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제26선거구"
+        "lang:ko": "제주특별자치도제26선거구"
       },
       "parent_id": "Q41164"
     },
@@ -358,7 +358,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제1선거구"
+        "lang:ko": "제주특별자치도제1선거구"
       },
       "parent_id": "Q41164"
     },
@@ -382,7 +382,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제28선거구"
+        "lang:ko": "제주특별자치도제28선거구"
       },
       "parent_id": "Q41164"
     },
@@ -406,7 +406,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제20선거구"
+        "lang:ko": "제주특별자치도제20선거구"
       },
       "parent_id": "Q41164"
     },
@@ -430,7 +430,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제6선거구"
+        "lang:ko": "제주특별자치도제6선거구"
       },
       "parent_id": "Q41164"
     },
@@ -454,7 +454,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제21선거구"
+        "lang:ko": "제주특별자치도제21선거구"
       },
       "parent_id": "Q41164"
     },
@@ -478,7 +478,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제9선거구"
+        "lang:ko": "제주특별자치도제9선거구"
       },
       "parent_id": "Q41164"
     },
@@ -502,7 +502,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제10선거구"
+        "lang:ko": "제주특별자치도제10선거구"
       },
       "parent_id": "Q41164"
     },
@@ -526,7 +526,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제29선거구"
+        "lang:ko": "제주특별자치도제29선거구"
       },
       "parent_id": "Q41164"
     },
@@ -550,7 +550,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제12선거구"
+        "lang:ko": "제주특별자치도제12선거구"
       },
       "parent_id": "Q41164"
     },
@@ -574,7 +574,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제18선거구"
+        "lang:ko": "제주특별자치도제18선거구"
       },
       "parent_id": "Q41164"
     },
@@ -598,7 +598,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제23선거구"
+        "lang:ko": "제주특별자치도제23선거구"
       },
       "parent_id": "Q41164"
     },
@@ -622,7 +622,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제5선거구"
+        "lang:ko": "제주특별자치도제5선거구"
       },
       "parent_id": "Q41164"
     },
@@ -646,7 +646,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제15선거구"
+        "lang:ko": "제주특별자치도제15선거구"
       },
       "parent_id": "Q41164"
     },
@@ -670,7 +670,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제2선거구"
+        "lang:ko": "제주특별자치도제2선거구"
       },
       "parent_id": "Q41164"
     },
@@ -694,7 +694,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제8선거구"
+        "lang:ko": "제주특별자치도제8선거구"
       },
       "parent_id": "Q41164"
     },
@@ -718,7 +718,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제14선거구"
+        "lang:ko": "제주특별자치도제14선거구"
       },
       "parent_id": "Q41164"
     },
@@ -742,7 +742,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제17선거구"
+        "lang:ko": "제주특별자치도제17선거구"
       },
       "parent_id": "Q41164"
     },
@@ -766,7 +766,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제22선거구"
+        "lang:ko": "제주특별자치도제22선거구"
       },
       "parent_id": "Q41164"
     },
@@ -790,7 +790,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제24선거구"
+        "lang:ko": "제주특별자치도제24선거구"
       },
       "parent_id": "Q41164"
     },
@@ -814,7 +814,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제3선거구"
+        "lang:ko": "제주특별자치도제3선거구"
       },
       "parent_id": "Q41164"
     },
@@ -838,7 +838,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제16선거구"
+        "lang:ko": "제주특별자치도제16선거구"
       },
       "parent_id": "Q41164"
     },
@@ -862,7 +862,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제7선거구"
+        "lang:ko": "제주특별자치도제7선거구"
       },
       "parent_id": "Q41164"
     },
@@ -886,7 +886,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제27선거구"
+        "lang:ko": "제주특별자치도제27선거구"
       },
       "parent_id": "Q41164"
     },
@@ -910,7 +910,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제4선거구"
+        "lang:ko": "제주특별자치도제4선거구"
       },
       "parent_id": "Q41164"
     },
@@ -934,7 +934,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제25선거구"
+        "lang:ko": "제주특별자치도제25선거구"
       },
       "parent_id": "Q41164"
     },
@@ -958,7 +958,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도제11선거구"
+        "lang:ko": "제주특별자치도제11선거구"
       },
       "parent_id": "Q41164"
     },
@@ -982,7 +982,7 @@
         "lang:en": "FLACS Council Constituency of Jeju"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도 비례대표 선거구"
+        "lang:ko": "제주특별자치도 비례대표 선거구"
       },
       "parent_id": "Q41164"
     },
@@ -1005,8 +1005,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q20779829/Q50798444/popolo-m17n.json
+++ b/legislative/Q20779829/Q50798444/popolo-m17n.json
@@ -250,8 +250,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gyeonggi-do",
-        "lang:ko_KR": "경기도"
+        "lang:en": "Gyeonggi-do",
+        "lang:ko": "경기도"
       },
       "parent_id": "Q884"
     },
@@ -275,7 +275,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "용인시제8선거구"
+        "lang:ko": "용인시제8선거구"
       },
       "parent_id": "Q20937"
     },
@@ -299,7 +299,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "고양시제4선거구"
+        "lang:ko": "고양시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -323,7 +323,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "용인시제2선거구"
+        "lang:ko": "용인시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -347,7 +347,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "부천시제1선거구"
+        "lang:ko": "부천시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -371,7 +371,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "화성시제3선거구"
+        "lang:ko": "화성시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -395,7 +395,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "수원시제3선거구"
+        "lang:ko": "수원시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -419,7 +419,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "군포시제1선거구"
+        "lang:ko": "군포시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -443,7 +443,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "성남시제1선거구"
+        "lang:ko": "성남시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -467,7 +467,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안산시제6선거구"
+        "lang:ko": "안산시제6선거구"
       },
       "parent_id": "Q20937"
     },
@@ -491,7 +491,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "남양주시제2선거구"
+        "lang:ko": "남양주시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -515,7 +515,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "의정부시제2선거구"
+        "lang:ko": "의정부시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -539,7 +539,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "성남시제5선거구"
+        "lang:ko": "성남시제5선거구"
       },
       "parent_id": "Q20937"
     },
@@ -563,7 +563,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "시흥시제4선거구"
+        "lang:ko": "시흥시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -587,7 +587,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "광주시제1선거구"
+        "lang:ko": "광주시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -611,7 +611,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "평택시제3선거구"
+        "lang:ko": "평택시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -635,7 +635,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "남양주시제3선거구"
+        "lang:ko": "남양주시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -659,7 +659,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "파주시제2선거구"
+        "lang:ko": "파주시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -683,7 +683,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안양시제6선거구"
+        "lang:ko": "안양시제6선거구"
       },
       "parent_id": "Q20937"
     },
@@ -707,7 +707,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안양시제4선거구"
+        "lang:ko": "안양시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -731,7 +731,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "가평군선거구"
+        "lang:ko": "가평군선거구"
       },
       "parent_id": "Q20937"
     },
@@ -755,7 +755,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "광명시제1선거구"
+        "lang:ko": "광명시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -779,7 +779,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "용인시제4선거구"
+        "lang:ko": "용인시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -803,7 +803,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "성남시제8선거구"
+        "lang:ko": "성남시제8선거구"
       },
       "parent_id": "Q20937"
     },
@@ -827,7 +827,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안양시제5선거구"
+        "lang:ko": "안양시제5선거구"
       },
       "parent_id": "Q20937"
     },
@@ -851,7 +851,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "화성시제4선거구"
+        "lang:ko": "화성시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -875,7 +875,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "부천시제5선거구"
+        "lang:ko": "부천시제5선거구"
       },
       "parent_id": "Q20937"
     },
@@ -899,7 +899,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안양시제2선거구"
+        "lang:ko": "안양시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -923,7 +923,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "고양시제6선거구"
+        "lang:ko": "고양시제6선거구"
       },
       "parent_id": "Q20937"
     },
@@ -947,7 +947,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "이천시제2선거구"
+        "lang:ko": "이천시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -971,7 +971,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "성남시제6선거구"
+        "lang:ko": "성남시제6선거구"
       },
       "parent_id": "Q20937"
     },
@@ -995,7 +995,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "고양시제5선거구"
+        "lang:ko": "고양시제5선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1019,7 +1019,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "성남시제7선거구"
+        "lang:ko": "성남시제7선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1043,7 +1043,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "수원시제5선거구"
+        "lang:ko": "수원시제5선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1067,7 +1067,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "김포시제2선거구"
+        "lang:ko": "김포시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1091,7 +1091,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "여주시제1선거구"
+        "lang:ko": "여주시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1115,7 +1115,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "성남시제4선거구"
+        "lang:ko": "성남시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1139,7 +1139,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "용인시제7선거구"
+        "lang:ko": "용인시제7선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1163,7 +1163,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "파주시제4선거구"
+        "lang:ko": "파주시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1187,7 +1187,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "김포시제3선거구"
+        "lang:ko": "김포시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1211,7 +1211,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "용인시제6선거구"
+        "lang:ko": "용인시제6선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1235,7 +1235,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안성시제1선거구"
+        "lang:ko": "안성시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1259,7 +1259,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "부천시제8선거구"
+        "lang:ko": "부천시제8선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1283,7 +1283,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "용인시제1선거구"
+        "lang:ko": "용인시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1307,7 +1307,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "용인시제5선거구"
+        "lang:ko": "용인시제5선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1331,7 +1331,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "성남시제2선거구"
+        "lang:ko": "성남시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1355,7 +1355,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "과천시선거구"
+        "lang:ko": "과천시선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1379,7 +1379,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "고양시제2선거구"
+        "lang:ko": "고양시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1403,7 +1403,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "양평군제2선거구"
+        "lang:ko": "양평군제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1427,7 +1427,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안산시제7선거구"
+        "lang:ko": "안산시제7선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1451,7 +1451,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "고양시제8선거구"
+        "lang:ko": "고양시제8선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1475,7 +1475,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "파주시제1선거구"
+        "lang:ko": "파주시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1499,7 +1499,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "광주시제2선거구"
+        "lang:ko": "광주시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1523,7 +1523,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안양시제3선거구"
+        "lang:ko": "안양시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1547,7 +1547,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "포천시제1선거구"
+        "lang:ko": "포천시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1571,7 +1571,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "남양주시제4선거구"
+        "lang:ko": "남양주시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1595,7 +1595,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "오산시제2선거구"
+        "lang:ko": "오산시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1619,7 +1619,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "남양주시제1선거구"
+        "lang:ko": "남양주시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1643,7 +1643,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "포천시제2선거구"
+        "lang:ko": "포천시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1667,7 +1667,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "수원시제1선거구"
+        "lang:ko": "수원시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1691,7 +1691,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "구리시제1선거구"
+        "lang:ko": "구리시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1715,7 +1715,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안산시제1선거구"
+        "lang:ko": "안산시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1739,7 +1739,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "수원시제2선거구"
+        "lang:ko": "수원시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1763,7 +1763,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "화성시제1선거구"
+        "lang:ko": "화성시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1787,7 +1787,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "의정부시제1선거구"
+        "lang:ko": "의정부시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1811,7 +1811,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "부천시제3선거구"
+        "lang:ko": "부천시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1835,7 +1835,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "연천군선거구"
+        "lang:ko": "연천군선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1859,7 +1859,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "부천시제7선거구"
+        "lang:ko": "부천시제7선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1883,7 +1883,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안산시제8선거구"
+        "lang:ko": "안산시제8선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1907,7 +1907,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "파주시제3선거구"
+        "lang:ko": "파주시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1931,7 +1931,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "구리시제2선거구"
+        "lang:ko": "구리시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1955,7 +1955,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "하남시제1선거구"
+        "lang:ko": "하남시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -1979,7 +1979,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "오산시제1선거구"
+        "lang:ko": "오산시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2003,7 +2003,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "고양시제7선거구"
+        "lang:ko": "고양시제7선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2027,7 +2027,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안성시제2선거구"
+        "lang:ko": "안성시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2051,7 +2051,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "동두천시제2선거구"
+        "lang:ko": "동두천시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2075,7 +2075,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안산시제5선거구"
+        "lang:ko": "안산시제5선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2099,7 +2099,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "하남시제2선거구"
+        "lang:ko": "하남시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2123,7 +2123,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "성남시제3선거구"
+        "lang:ko": "성남시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2147,7 +2147,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "고양시제1선거구"
+        "lang:ko": "고양시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2171,7 +2171,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "수원시제8선거구"
+        "lang:ko": "수원시제8선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2195,7 +2195,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "수원시제9선거구"
+        "lang:ko": "수원시제9선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2219,7 +2219,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "의왕시제1선거구"
+        "lang:ko": "의왕시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2243,7 +2243,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "양평군제1선거구"
+        "lang:ko": "양평군제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2267,7 +2267,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "시흥시제2선거구"
+        "lang:ko": "시흥시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2291,7 +2291,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "광명시제2선거구"
+        "lang:ko": "광명시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2315,7 +2315,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "화성시제2선거구"
+        "lang:ko": "화성시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2339,7 +2339,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "양주시제2선거구"
+        "lang:ko": "양주시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2363,7 +2363,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "시흥시제3선거구"
+        "lang:ko": "시흥시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2387,7 +2387,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "평택시제2선거구"
+        "lang:ko": "평택시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2411,7 +2411,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "광명시제4선거구"
+        "lang:ko": "광명시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2435,7 +2435,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "평택시제4선거구"
+        "lang:ko": "평택시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2459,7 +2459,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "수원시제6선거구"
+        "lang:ko": "수원시제6선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2483,7 +2483,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "평택시제1선거구"
+        "lang:ko": "평택시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2507,7 +2507,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "김포시제1선거구"
+        "lang:ko": "김포시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2531,7 +2531,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "동두천시제1선거구"
+        "lang:ko": "동두천시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2555,7 +2555,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "수원시제7선거구"
+        "lang:ko": "수원시제7선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2579,7 +2579,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "부천시제2선거구"
+        "lang:ko": "부천시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2603,7 +2603,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "이천시제1선거구"
+        "lang:ko": "이천시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2627,7 +2627,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "의정부시제4선거구"
+        "lang:ko": "의정부시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2651,7 +2651,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안산시제2선거구"
+        "lang:ko": "안산시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2675,7 +2675,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "용인시제3선거구"
+        "lang:ko": "용인시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2699,7 +2699,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "광명시제3선거구"
+        "lang:ko": "광명시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2723,7 +2723,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "부천시제4선거구"
+        "lang:ko": "부천시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2747,7 +2747,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "고양시제3선거구"
+        "lang:ko": "고양시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2771,7 +2771,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "시흥시제1선거구"
+        "lang:ko": "시흥시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2795,7 +2795,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "양주시제1선거구"
+        "lang:ko": "양주시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2819,7 +2819,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "의왕시제2선거구"
+        "lang:ko": "의왕시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2843,7 +2843,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안양시제1선거구"
+        "lang:ko": "안양시제1선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2867,7 +2867,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "군포시제2선거구"
+        "lang:ko": "군포시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2891,7 +2891,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "남양주시제5선거구"
+        "lang:ko": "남양주시제5선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2915,7 +2915,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "수원시제4선거구"
+        "lang:ko": "수원시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2939,7 +2939,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "부천시제6선거구"
+        "lang:ko": "부천시제6선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2963,7 +2963,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "여주시제2선거구"
+        "lang:ko": "여주시제2선거구"
       },
       "parent_id": "Q20937"
     },
@@ -2987,7 +2987,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안산시제4선거구"
+        "lang:ko": "안산시제4선거구"
       },
       "parent_id": "Q20937"
     },
@@ -3011,7 +3011,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "안산시제3선거구"
+        "lang:ko": "안산시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -3035,7 +3035,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "의정부시제3선거구"
+        "lang:ko": "의정부시제3선거구"
       },
       "parent_id": "Q20937"
     },
@@ -3059,7 +3059,7 @@
         "lang:en": "FLACS Council Constituency of Gyeonggi Province"
       },
       "name": {
-        "lang:ko_KR": "경기도 비례대표 선거구"
+        "lang:ko": "경기도 비례대표 선거구"
       },
       "parent_id": "Q20937"
     },
@@ -3082,8 +3082,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q21060148/Q50798429/popolo-m17n.json
+++ b/legislative/Q21060148/Q50798429/popolo-m17n.json
@@ -235,8 +235,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Jeollabuk-do",
-        "lang:ko_KR": "전라북도"
+        "lang:en": "Jeollabuk-do",
+        "lang:ko": "전라북도"
       },
       "parent_id": "Q884"
     },
@@ -260,7 +260,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전주시제1선거구"
+        "lang:ko": "전주시제1선거구"
       },
       "parent_id": "Q41157"
     },
@@ -284,7 +284,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "순창군선거구"
+        "lang:ko": "순창군선거구"
       },
       "parent_id": "Q41157"
     },
@@ -308,7 +308,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "무주군선거구"
+        "lang:ko": "무주군선거구"
       },
       "parent_id": "Q41157"
     },
@@ -332,7 +332,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "완주군제2선거구"
+        "lang:ko": "완주군제2선거구"
       },
       "parent_id": "Q41157"
     },
@@ -356,7 +356,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "김제시제2선거구"
+        "lang:ko": "김제시제2선거구"
       },
       "parent_id": "Q41157"
     },
@@ -380,7 +380,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "정읍시제2선거구"
+        "lang:ko": "정읍시제2선거구"
       },
       "parent_id": "Q41157"
     },
@@ -404,7 +404,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "남원시제2선거구"
+        "lang:ko": "남원시제2선거구"
       },
       "parent_id": "Q41157"
     },
@@ -428,7 +428,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전주시제7선거구"
+        "lang:ko": "전주시제7선거구"
       },
       "parent_id": "Q41157"
     },
@@ -452,7 +452,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "군산시제3선거구"
+        "lang:ko": "군산시제3선거구"
       },
       "parent_id": "Q41157"
     },
@@ -476,7 +476,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전주시제9선거구"
+        "lang:ko": "전주시제9선거구"
       },
       "parent_id": "Q41157"
     },
@@ -500,7 +500,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전주시제4선거구"
+        "lang:ko": "전주시제4선거구"
       },
       "parent_id": "Q41157"
     },
@@ -524,7 +524,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "익산시제4선거구"
+        "lang:ko": "익산시제4선거구"
       },
       "parent_id": "Q41157"
     },
@@ -548,7 +548,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "완주군제1선거구"
+        "lang:ko": "완주군제1선거구"
       },
       "parent_id": "Q41157"
     },
@@ -572,7 +572,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "군산시제4선거구"
+        "lang:ko": "군산시제4선거구"
       },
       "parent_id": "Q41157"
     },
@@ -596,7 +596,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전주시제8선거구"
+        "lang:ko": "전주시제8선거구"
       },
       "parent_id": "Q41157"
     },
@@ -620,7 +620,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전주시제6선거구"
+        "lang:ko": "전주시제6선거구"
       },
       "parent_id": "Q41157"
     },
@@ -644,7 +644,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전주시제2선거구"
+        "lang:ko": "전주시제2선거구"
       },
       "parent_id": "Q41157"
     },
@@ -668,7 +668,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "장수군선거구"
+        "lang:ko": "장수군선거구"
       },
       "parent_id": "Q41157"
     },
@@ -692,7 +692,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "익산시제1선거구"
+        "lang:ko": "익산시제1선거구"
       },
       "parent_id": "Q41157"
     },
@@ -716,7 +716,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "김제시제1선거구"
+        "lang:ko": "김제시제1선거구"
       },
       "parent_id": "Q41157"
     },
@@ -740,7 +740,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "부안군제1선거구"
+        "lang:ko": "부안군제1선거구"
       },
       "parent_id": "Q41157"
     },
@@ -764,7 +764,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "정읍시제1선거구"
+        "lang:ko": "정읍시제1선거구"
       },
       "parent_id": "Q41157"
     },
@@ -788,7 +788,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "진안군선거구"
+        "lang:ko": "진안군선거구"
       },
       "parent_id": "Q41157"
     },
@@ -812,7 +812,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "고창군제1선거구"
+        "lang:ko": "고창군제1선거구"
       },
       "parent_id": "Q41157"
     },
@@ -836,7 +836,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "임실군선거구"
+        "lang:ko": "임실군선거구"
       },
       "parent_id": "Q41157"
     },
@@ -860,7 +860,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "부안군제2선거구"
+        "lang:ko": "부안군제2선거구"
       },
       "parent_id": "Q41157"
     },
@@ -884,7 +884,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전주시제3선거구"
+        "lang:ko": "전주시제3선거구"
       },
       "parent_id": "Q41157"
     },
@@ -908,7 +908,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "군산시제1선거구"
+        "lang:ko": "군산시제1선거구"
       },
       "parent_id": "Q41157"
     },
@@ -932,7 +932,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "남원시제1선거구"
+        "lang:ko": "남원시제1선거구"
       },
       "parent_id": "Q41157"
     },
@@ -956,7 +956,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "익산시제3선거구"
+        "lang:ko": "익산시제3선거구"
       },
       "parent_id": "Q41157"
     },
@@ -980,7 +980,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전주시제5선거구"
+        "lang:ko": "전주시제5선거구"
       },
       "parent_id": "Q41157"
     },
@@ -1004,7 +1004,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "익산시제2선거구"
+        "lang:ko": "익산시제2선거구"
       },
       "parent_id": "Q41157"
     },
@@ -1028,7 +1028,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "군산시제2선거구"
+        "lang:ko": "군산시제2선거구"
       },
       "parent_id": "Q41157"
     },
@@ -1052,7 +1052,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "고창군제2선거구"
+        "lang:ko": "고창군제2선거구"
       },
       "parent_id": "Q41157"
     },
@@ -1076,7 +1076,7 @@
         "lang:en": "FLACS Council Constituency of North Jeolla Province"
       },
       "name": {
-        "lang:ko_KR": "전라북도 비례대표 선거구"
+        "lang:ko": "전라북도 비례대표 선거구"
       },
       "parent_id": "Q41157"
     },
@@ -1099,8 +1099,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }

--- a/legislative/Q494162/Q22971549/popolo-m17n.json
+++ b/legislative/Q494162/Q22971549/popolo-m17n.json
@@ -227,8 +227,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Busan",
-        "lang:ko_KR": "부산광역시"
+        "lang:en": "Busan",
+        "lang:ko": "부산광역시"
       },
       "parent_id": "Q884"
     },
@@ -252,8 +252,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Daejeon",
-        "lang:ko_KR": "대전광역시"
+        "lang:en": "Daejeon",
+        "lang:ko": "대전광역시"
       },
       "parent_id": "Q884"
     },
@@ -277,8 +277,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Daegu",
-        "lang:ko_KR": "대구광역시"
+        "lang:en": "Daegu",
+        "lang:ko": "대구광역시"
       },
       "parent_id": "Q884"
     },
@@ -302,8 +302,8 @@
         "lang:en": "special autonomous city in South Korea"
       },
       "name": {
-        "lang:en_US": "Sejong Special Self-Governing City",
-        "lang:ko_KR": "세종특별자치시"
+        "lang:en": "Sejong Special Self-Governing City",
+        "lang:ko": "세종특별자치시"
       },
       "parent_id": "Q884"
     },
@@ -327,8 +327,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Incheon",
-        "lang:ko_KR": "인천광역시"
+        "lang:en": "Incheon",
+        "lang:ko": "인천광역시"
       },
       "parent_id": "Q884"
     },
@@ -352,8 +352,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gyeonggi-do",
-        "lang:ko_KR": "경기도"
+        "lang:en": "Gyeonggi-do",
+        "lang:ko": "경기도"
       },
       "parent_id": "Q884"
     },
@@ -377,8 +377,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Chungcheongbuk-do",
-        "lang:ko_KR": "충청북도"
+        "lang:en": "Chungcheongbuk-do",
+        "lang:ko": "충청북도"
       },
       "parent_id": "Q884"
     },
@@ -402,8 +402,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Chungcheongnam-do",
-        "lang:ko_KR": "충청남도"
+        "lang:en": "Chungcheongnam-do",
+        "lang:ko": "충청남도"
       },
       "parent_id": "Q884"
     },
@@ -427,8 +427,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gangwon-do",
-        "lang:ko_KR": "강원도"
+        "lang:en": "Gangwon-do",
+        "lang:ko": "강원도"
       },
       "parent_id": "Q884"
     },
@@ -452,8 +452,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gyeongsangnam-do",
-        "lang:ko_KR": "경상남도"
+        "lang:en": "Gyeongsangnam-do",
+        "lang:ko": "경상남도"
       },
       "parent_id": "Q884"
     },
@@ -477,8 +477,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Gyeongsangbuk-do",
-        "lang:ko_KR": "경상북도"
+        "lang:en": "Gyeongsangbuk-do",
+        "lang:ko": "경상북도"
       },
       "parent_id": "Q884"
     },
@@ -502,8 +502,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Jeollabuk-do",
-        "lang:ko_KR": "전라북도"
+        "lang:en": "Jeollabuk-do",
+        "lang:ko": "전라북도"
       },
       "parent_id": "Q884"
     },
@@ -527,8 +527,8 @@
         "lang:en": "province of South Korea"
       },
       "name": {
-        "lang:en_US": "Jeollanam-do",
-        "lang:ko_KR": "전라남도"
+        "lang:en": "Jeollanam-do",
+        "lang:ko": "전라남도"
       },
       "parent_id": "Q884"
     },
@@ -552,8 +552,8 @@
         "lang:en": "Special Self-governing Province of South Korea"
       },
       "name": {
-        "lang:en_US": "Jeju Special Self-Governing Province",
-        "lang:ko_KR": "제주특별자치도"
+        "lang:en": "Jeju Special Self-Governing Province",
+        "lang:ko": "제주특별자치도"
       },
       "parent_id": "Q884"
     },
@@ -577,8 +577,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Ulsan",
-        "lang:ko_KR": "울산광역시"
+        "lang:en": "Ulsan",
+        "lang:ko": "울산광역시"
       },
       "parent_id": "Q884"
     },
@@ -602,8 +602,8 @@
         "lang:en": "metropolitan city of South Korea"
       },
       "name": {
-        "lang:en_US": "Gwangju",
-        "lang:ko_KR": "광주광역시"
+        "lang:en": "Gwangju",
+        "lang:ko": "광주광역시"
       },
       "parent_id": "Q884"
     },
@@ -627,7 +627,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 종로구"
+        "lang:ko": "서울특별시 종로구"
       },
       "parent_id": "Q8684"
     },
@@ -651,7 +651,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 고양시갑"
+        "lang:ko": "경기도 고양시갑"
       },
       "parent_id": "Q20937"
     },
@@ -675,7 +675,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 금정구"
+        "lang:ko": "부산광역시 금정구"
       },
       "parent_id": "Q16520"
     },
@@ -699,7 +699,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "세종특별자치시"
+        "lang:ko": "세종특별자치시"
       },
       "parent_id": "Q20929"
     },
@@ -723,7 +723,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도 제주시갑"
+        "lang:ko": "제주특별자치도 제주시갑"
       },
       "parent_id": "Q41164"
     },
@@ -747,7 +747,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 중구영도구"
+        "lang:ko": "부산광역시 중구영도구"
       },
       "parent_id": "Q16520"
     },
@@ -771,7 +771,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 동작구갑"
+        "lang:ko": "서울특별시 동작구갑"
       },
       "parent_id": "Q8684"
     },
@@ -795,7 +795,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청북도 청주시흥덕구"
+        "lang:ko": "충청북도 청주시흥덕구"
       },
       "parent_id": "Q41066"
     },
@@ -819,7 +819,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 동두천시연천군"
+        "lang:ko": "경기도 동두천시연천군"
       },
       "parent_id": "Q20937"
     },
@@ -843,7 +843,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강북구을"
+        "lang:ko": "서울특별시 강북구을"
       },
       "parent_id": "Q8684"
     },
@@ -867,7 +867,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 광주시을"
+        "lang:ko": "경기도 광주시을"
       },
       "parent_id": "Q20937"
     },
@@ -891,7 +891,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 마포구갑"
+        "lang:ko": "서울특별시 마포구갑"
       },
       "parent_id": "Q8684"
     },
@@ -915,7 +915,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 구로구을"
+        "lang:ko": "서울특별시 구로구을"
       },
       "parent_id": "Q8684"
     },
@@ -939,7 +939,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 창원시마산회원구"
+        "lang:ko": "경상남도 창원시마산회원구"
       },
       "parent_id": "Q41151"
     },
@@ -963,7 +963,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대전광역시 중구"
+        "lang:ko": "대전광역시 중구"
       },
       "parent_id": "Q20921"
     },
@@ -987,7 +987,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 남원시임실군순창군"
+        "lang:ko": "전라북도 남원시임실군순창군"
       },
       "parent_id": "Q41157"
     },
@@ -1011,7 +1011,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "강원도 강릉시"
+        "lang:ko": "강원도 강릉시"
       },
       "parent_id": "Q41071"
     },
@@ -1035,7 +1035,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "광주광역시 서구갑"
+        "lang:ko": "광주광역시 서구갑"
       },
       "parent_id": "Q41283"
     },
@@ -1059,7 +1059,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 계양구을"
+        "lang:ko": "인천광역시 계양구을"
       },
       "parent_id": "Q20934"
     },
@@ -1083,7 +1083,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 천안시갑"
+        "lang:ko": "충청남도 천안시갑"
       },
       "parent_id": "Q41070"
     },
@@ -1107,7 +1107,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 여주시양평군"
+        "lang:ko": "경기도 여주시양평군"
       },
       "parent_id": "Q20937"
     },
@@ -1131,7 +1131,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 광진구을"
+        "lang:ko": "서울특별시 광진구을"
       },
       "parent_id": "Q8684"
     },
@@ -1155,7 +1155,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "강원도 속초시고성군양양군"
+        "lang:ko": "강원도 속초시고성군양양군"
       },
       "parent_id": "Q41071"
     },
@@ -1179,7 +1179,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 안성시"
+        "lang:ko": "경기도 안성시"
       },
       "parent_id": "Q20937"
     },
@@ -1203,7 +1203,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 중구동구강화군옹진군"
+        "lang:ko": "인천광역시 중구동구강화군옹진군"
       },
       "parent_id": "Q20934"
     },
@@ -1227,7 +1227,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 서대문구갑"
+        "lang:ko": "서울특별시 서대문구갑"
       },
       "parent_id": "Q8684"
     },
@@ -1251,7 +1251,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 금천구"
+        "lang:ko": "서울특별시 금천구"
       },
       "parent_id": "Q8684"
     },
@@ -1275,7 +1275,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 포항시북구"
+        "lang:ko": "경상북도 포항시북구"
       },
       "parent_id": "Q41154"
     },
@@ -1299,7 +1299,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 서산시태안군"
+        "lang:ko": "충청남도 서산시태안군"
       },
       "parent_id": "Q41070"
     },
@@ -1323,7 +1323,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 광명시을"
+        "lang:ko": "경기도 광명시을"
       },
       "parent_id": "Q20937"
     },
@@ -1347,7 +1347,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 김포시갑"
+        "lang:ko": "경기도 김포시갑"
       },
       "parent_id": "Q20937"
     },
@@ -1371,7 +1371,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 수성구갑"
+        "lang:ko": "대구광역시 수성구갑"
       },
       "parent_id": "Q20927"
     },
@@ -1395,7 +1395,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 연제구"
+        "lang:ko": "부산광역시 연제구"
       },
       "parent_id": "Q16520"
     },
@@ -1419,7 +1419,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 익산시을"
+        "lang:ko": "전라북도 익산시을"
       },
       "parent_id": "Q41157"
     },
@@ -1443,7 +1443,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 오산시"
+        "lang:ko": "경기도 오산시"
       },
       "parent_id": "Q20937"
     },
@@ -1467,7 +1467,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "울산광역시 중구"
+        "lang:ko": "울산광역시 중구"
       },
       "parent_id": "Q41278"
     },
@@ -1491,7 +1491,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 달서구갑"
+        "lang:ko": "대구광역시 달서구갑"
       },
       "parent_id": "Q20927"
     },
@@ -1515,7 +1515,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 중구성동구갑"
+        "lang:ko": "서울특별시 중구성동구갑"
       },
       "parent_id": "Q8684"
     },
@@ -1539,7 +1539,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 부산진구을"
+        "lang:ko": "부산광역시 부산진구을"
       },
       "parent_id": "Q16520"
     },
@@ -1563,7 +1563,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대전광역시 동구"
+        "lang:ko": "대전광역시 동구"
       },
       "parent_id": "Q20921"
     },
@@ -1587,7 +1587,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대전광역시 서구갑"
+        "lang:ko": "대전광역시 서구갑"
       },
       "parent_id": "Q20921"
     },
@@ -1611,7 +1611,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 북구을"
+        "lang:ko": "대구광역시 북구을"
       },
       "parent_id": "Q20927"
     },
@@ -1635,7 +1635,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 달서구병"
+        "lang:ko": "대구광역시 달서구병"
       },
       "parent_id": "Q20927"
     },
@@ -1659,7 +1659,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 익산시갑"
+        "lang:ko": "전라북도 익산시갑"
       },
       "parent_id": "Q41157"
     },
@@ -1683,7 +1683,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 연수구을"
+        "lang:ko": "인천광역시 연수구을"
       },
       "parent_id": "Q20934"
     },
@@ -1707,7 +1707,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 영천시청도군"
+        "lang:ko": "경상북도 영천시청도군"
       },
       "parent_id": "Q41154"
     },
@@ -1731,7 +1731,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청북도 보은군옥천군영동군괴산군"
+        "lang:ko": "충청북도 보은군옥천군영동군괴산군"
       },
       "parent_id": "Q41066"
     },
@@ -1755,7 +1755,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청북도 청주시청원구"
+        "lang:ko": "충청북도 청주시청원구"
       },
       "parent_id": "Q41066"
     },
@@ -1779,7 +1779,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 성남시분당구을"
+        "lang:ko": "경기도 성남시분당구을"
       },
       "parent_id": "Q20937"
     },
@@ -1803,7 +1803,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 동작구을"
+        "lang:ko": "서울특별시 동작구을"
       },
       "parent_id": "Q8684"
     },
@@ -1827,7 +1827,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 천안시병"
+        "lang:ko": "충청남도 천안시병"
       },
       "parent_id": "Q41070"
     },
@@ -1851,7 +1851,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도 제주시을"
+        "lang:ko": "제주특별자치도 제주시을"
       },
       "parent_id": "Q41164"
     },
@@ -1875,7 +1875,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 영양군영덕군봉화군울진군"
+        "lang:ko": "경상북도 영양군영덕군봉화군울진군"
       },
       "parent_id": "Q41154"
     },
@@ -1899,7 +1899,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 성북구갑"
+        "lang:ko": "서울특별시 성북구갑"
       },
       "parent_id": "Q8684"
     },
@@ -1923,7 +1923,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 안산시단원구을"
+        "lang:ko": "경기도 안산시단원구을"
       },
       "parent_id": "Q20937"
     },
@@ -1947,7 +1947,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "광주광역시 동구남구갑"
+        "lang:ko": "광주광역시 동구남구갑"
       },
       "parent_id": "Q41283"
     },
@@ -1971,7 +1971,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 안산시단원구갑"
+        "lang:ko": "경기도 안산시단원구갑"
       },
       "parent_id": "Q20937"
     },
@@ -1995,7 +1995,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강서구을"
+        "lang:ko": "서울특별시 강서구을"
       },
       "parent_id": "Q8684"
     },
@@ -2019,7 +2019,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 남구을"
+        "lang:ko": "부산광역시 남구을"
       },
       "parent_id": "Q16520"
     },
@@ -2043,7 +2043,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 광명시갑"
+        "lang:ko": "경기도 광명시갑"
       },
       "parent_id": "Q20937"
     },
@@ -2067,7 +2067,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 구미시을"
+        "lang:ko": "경상북도 구미시을"
       },
       "parent_id": "Q41154"
     },
@@ -2091,7 +2091,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 안양시동안구갑"
+        "lang:ko": "경기도 안양시동안구갑"
       },
       "parent_id": "Q20937"
     },
@@ -2115,7 +2115,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 전주시갑"
+        "lang:ko": "전라북도 전주시갑"
       },
       "parent_id": "Q41157"
     },
@@ -2139,7 +2139,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 완주군진안군무주군장수군"
+        "lang:ko": "전라북도 완주군진안군무주군장수군"
       },
       "parent_id": "Q41157"
     },
@@ -2163,7 +2163,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 부천시원미구갑"
+        "lang:ko": "경기도 부천시원미구갑"
       },
       "parent_id": "Q20937"
     },
@@ -2187,7 +2187,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 영등포구을"
+        "lang:ko": "서울특별시 영등포구을"
       },
       "parent_id": "Q8684"
     },
@@ -2211,7 +2211,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 의정부시갑"
+        "lang:ko": "경기도 의정부시갑"
       },
       "parent_id": "Q20937"
     },
@@ -2235,7 +2235,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청북도 청주시상당구"
+        "lang:ko": "충청북도 청주시상당구"
       },
       "parent_id": "Q41066"
     },
@@ -2259,7 +2259,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "강원도 원주시갑"
+        "lang:ko": "강원도 원주시갑"
       },
       "parent_id": "Q41071"
     },
@@ -2283,7 +2283,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 성북구을"
+        "lang:ko": "서울특별시 성북구을"
       },
       "parent_id": "Q8684"
     },
@@ -2307,7 +2307,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청북도 증평군진천군음성군"
+        "lang:ko": "충청북도 증평군진천군음성군"
       },
       "parent_id": "Q41066"
     },
@@ -2331,7 +2331,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 동대문구을"
+        "lang:ko": "서울특별시 동대문구을"
       },
       "parent_id": "Q8684"
     },
@@ -2355,7 +2355,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대전광역시 유성구갑"
+        "lang:ko": "대전광역시 유성구갑"
       },
       "parent_id": "Q20921"
     },
@@ -2379,7 +2379,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 서초구을"
+        "lang:ko": "서울특별시 서초구을"
       },
       "parent_id": "Q8684"
     },
@@ -2403,7 +2403,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 포항시남구울릉군"
+        "lang:ko": "경상북도 포항시남구울릉군"
       },
       "parent_id": "Q41154"
     },
@@ -2427,7 +2427,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 고흥군보성군장흥군강진군"
+        "lang:ko": "전라남도 고흥군보성군장흥군강진군"
       },
       "parent_id": "Q41161"
     },
@@ -2451,7 +2451,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 진주시갑"
+        "lang:ko": "경상남도 진주시갑"
       },
       "parent_id": "Q41151"
     },
@@ -2475,7 +2475,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 부평구을"
+        "lang:ko": "인천광역시 부평구을"
       },
       "parent_id": "Q20934"
     },
@@ -2499,7 +2499,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 북구갑"
+        "lang:ko": "대구광역시 북구갑"
       },
       "parent_id": "Q20927"
     },
@@ -2523,7 +2523,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 전주시병"
+        "lang:ko": "전라북도 전주시병"
       },
       "parent_id": "Q41157"
     },
@@ -2547,7 +2547,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "강원도 태백시횡성군영월군평창군정선군"
+        "lang:ko": "강원도 태백시횡성군영월군평창군정선군"
       },
       "parent_id": "Q41071"
     },
@@ -2571,7 +2571,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 영주시문경시예천군"
+        "lang:ko": "경상북도 영주시문경시예천군"
       },
       "parent_id": "Q41154"
     },
@@ -2595,7 +2595,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 전주시을"
+        "lang:ko": "전라북도 전주시을"
       },
       "parent_id": "Q41157"
     },
@@ -2619,7 +2619,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 노원구병"
+        "lang:ko": "서울특별시 노원구병"
       },
       "parent_id": "Q8684"
     },
@@ -2643,7 +2643,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 북구강서구갑"
+        "lang:ko": "부산광역시 북구강서구갑"
       },
       "parent_id": "Q16520"
     },
@@ -2667,7 +2667,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 의정부시을"
+        "lang:ko": "경기도 의정부시을"
       },
       "parent_id": "Q20937"
     },
@@ -2691,7 +2691,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 구로구갑"
+        "lang:ko": "서울특별시 구로구갑"
       },
       "parent_id": "Q8684"
     },
@@ -2715,7 +2715,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 안양시만안구"
+        "lang:ko": "경기도 안양시만안구"
       },
       "parent_id": "Q20937"
     },
@@ -2739,7 +2739,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 노원구을"
+        "lang:ko": "서울특별시 노원구을"
       },
       "parent_id": "Q8684"
     },
@@ -2763,7 +2763,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 부천시오정구"
+        "lang:ko": "경기도 부천시오정구"
       },
       "parent_id": "Q20937"
     },
@@ -2787,7 +2787,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 목포시"
+        "lang:ko": "전라남도 목포시"
       },
       "parent_id": "Q41161"
     },
@@ -2811,7 +2811,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 성남시분당구갑"
+        "lang:ko": "경기도 성남시분당구갑"
       },
       "parent_id": "Q20937"
     },
@@ -2835,7 +2835,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 해운대구을"
+        "lang:ko": "부산광역시 해운대구을"
       },
       "parent_id": "Q16520"
     },
@@ -2859,7 +2859,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 여수시갑"
+        "lang:ko": "전라남도 여수시갑"
       },
       "parent_id": "Q41161"
     },
@@ -2883,7 +2883,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 김제시부안군"
+        "lang:ko": "전라북도 김제시부안군"
       },
       "parent_id": "Q41157"
     },
@@ -2907,7 +2907,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 남양주시갑"
+        "lang:ko": "경기도 남양주시갑"
       },
       "parent_id": "Q20937"
     },
@@ -2931,7 +2931,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강남구병"
+        "lang:ko": "서울특별시 강남구병"
       },
       "parent_id": "Q8684"
     },
@@ -2955,7 +2955,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대전광역시 대덕구"
+        "lang:ko": "대전광역시 대덕구"
       },
       "parent_id": "Q20921"
     },
@@ -2979,7 +2979,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 의왕시과천시"
+        "lang:ko": "경기도 의왕시과천시"
       },
       "parent_id": "Q20937"
     },
@@ -3003,7 +3003,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 당진시"
+        "lang:ko": "충청남도 당진시"
       },
       "parent_id": "Q41070"
     },
@@ -3027,7 +3027,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 시흥시갑"
+        "lang:ko": "경기도 시흥시갑"
       },
       "parent_id": "Q20937"
     },
@@ -3051,7 +3051,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 고령군성주군칠곡군"
+        "lang:ko": "경상북도 고령군성주군칠곡군"
       },
       "parent_id": "Q41154"
     },
@@ -3075,7 +3075,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 서구동구"
+        "lang:ko": "부산광역시 서구동구"
       },
       "parent_id": "Q16520"
     },
@@ -3099,7 +3099,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 영암군무안군신안군"
+        "lang:ko": "전라남도 영암군무안군신안군"
       },
       "parent_id": "Q41161"
     },
@@ -3123,7 +3123,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 공주시부여군청양군"
+        "lang:ko": "충청남도 공주시부여군청양군"
       },
       "parent_id": "Q41070"
     },
@@ -3147,7 +3147,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 송파구갑"
+        "lang:ko": "서울특별시 송파구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3171,7 +3171,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강동구을"
+        "lang:ko": "서울특별시 강동구을"
       },
       "parent_id": "Q8684"
     },
@@ -3195,7 +3195,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 평택시갑"
+        "lang:ko": "경기도 평택시갑"
       },
       "parent_id": "Q20937"
     },
@@ -3219,7 +3219,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강북구갑"
+        "lang:ko": "서울특별시 강북구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3243,7 +3243,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 달서구을"
+        "lang:ko": "대구광역시 달서구을"
       },
       "parent_id": "Q20927"
     },
@@ -3267,7 +3267,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 중랑구갑"
+        "lang:ko": "서울특별시 중랑구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3291,7 +3291,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "광주광역시 북구을"
+        "lang:ko": "광주광역시 북구을"
       },
       "parent_id": "Q41283"
     },
@@ -3315,7 +3315,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 부산진구갑"
+        "lang:ko": "부산광역시 부산진구갑"
       },
       "parent_id": "Q16520"
     },
@@ -3339,7 +3339,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 노원구갑"
+        "lang:ko": "서울특별시 노원구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3363,7 +3363,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 안양시동안구을"
+        "lang:ko": "경기도 안양시동안구을"
       },
       "parent_id": "Q20937"
     },
@@ -3387,7 +3387,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 양천구갑"
+        "lang:ko": "서울특별시 양천구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3411,7 +3411,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "광주광역시 광산구갑"
+        "lang:ko": "광주광역시 광산구갑"
       },
       "parent_id": "Q41283"
     },
@@ -3435,7 +3435,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "강원도 동해시삼척시"
+        "lang:ko": "강원도 동해시삼척시"
       },
       "parent_id": "Q41071"
     },
@@ -3459,7 +3459,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 은평구갑"
+        "lang:ko": "서울특별시 은평구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3483,7 +3483,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 창원시성산구"
+        "lang:ko": "경상남도 창원시성산구"
       },
       "parent_id": "Q41151"
     },
@@ -3507,7 +3507,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 부천시원미구을"
+        "lang:ko": "경기도 부천시원미구을"
       },
       "parent_id": "Q20937"
     },
@@ -3531,7 +3531,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 송파구병"
+        "lang:ko": "서울특별시 송파구병"
       },
       "parent_id": "Q8684"
     },
@@ -3555,7 +3555,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 순천시"
+        "lang:ko": "전라남도 순천시"
       },
       "parent_id": "Q41161"
     },
@@ -3579,7 +3579,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 송파구을"
+        "lang:ko": "서울특별시 송파구을"
       },
       "parent_id": "Q8684"
     },
@@ -3603,7 +3603,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 김해시갑"
+        "lang:ko": "경상남도 김해시갑"
       },
       "parent_id": "Q41151"
     },
@@ -3627,7 +3627,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 담양군함평군영광군장성군"
+        "lang:ko": "전라남도 담양군함평군영광군장성군"
       },
       "parent_id": "Q41161"
     },
@@ -3651,7 +3651,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 이천시"
+        "lang:ko": "경기도 이천시"
       },
       "parent_id": "Q20937"
     },
@@ -3675,7 +3675,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 양주시"
+        "lang:ko": "경기도 양주시"
       },
       "parent_id": "Q20937"
     },
@@ -3699,7 +3699,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 동구갑"
+        "lang:ko": "대구광역시 동구갑"
       },
       "parent_id": "Q20927"
     },
@@ -3723,7 +3723,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 광진구갑"
+        "lang:ko": "서울특별시 광진구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3747,7 +3747,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 군포시을"
+        "lang:ko": "경기도 군포시을"
       },
       "parent_id": "Q20937"
     },
@@ -3771,7 +3771,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 안동시"
+        "lang:ko": "경상북도 안동시"
       },
       "parent_id": "Q41154"
     },
@@ -3795,7 +3795,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 화성시병"
+        "lang:ko": "경기도 화성시병"
       },
       "parent_id": "Q20937"
     },
@@ -3819,7 +3819,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 사상구"
+        "lang:ko": "부산광역시 사상구"
       },
       "parent_id": "Q16520"
     },
@@ -3843,7 +3843,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강동구갑"
+        "lang:ko": "서울특별시 강동구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3867,7 +3867,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 영등포구갑"
+        "lang:ko": "서울특별시 영등포구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3891,7 +3891,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 성남시중원구"
+        "lang:ko": "경기도 성남시중원구"
       },
       "parent_id": "Q20937"
     },
@@ -3915,7 +3915,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 서초구갑"
+        "lang:ko": "서울특별시 서초구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3939,7 +3939,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 김해시을"
+        "lang:ko": "경상남도 김해시을"
       },
       "parent_id": "Q41151"
     },
@@ -3963,7 +3963,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 도봉구갑"
+        "lang:ko": "서울특별시 도봉구갑"
       },
       "parent_id": "Q8684"
     },
@@ -3987,7 +3987,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 창원시마산합포구"
+        "lang:ko": "경상남도 창원시마산합포구"
       },
       "parent_id": "Q41151"
     },
@@ -4011,7 +4011,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 사하구을"
+        "lang:ko": "부산광역시 사하구을"
       },
       "parent_id": "Q16520"
     },
@@ -4035,7 +4035,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 보령시서천군"
+        "lang:ko": "충청남도 보령시서천군"
       },
       "parent_id": "Q41070"
     },
@@ -4059,7 +4059,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 수원시정"
+        "lang:ko": "경기도 수원시정"
       },
       "parent_id": "Q20937"
     },
@@ -4083,7 +4083,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 동대문구갑"
+        "lang:ko": "서울특별시 동대문구갑"
       },
       "parent_id": "Q8684"
     },
@@ -4107,7 +4107,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 용인시병"
+        "lang:ko": "경기도 용인시병"
       },
       "parent_id": "Q20937"
     },
@@ -4131,7 +4131,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 사천시남해군하동군"
+        "lang:ko": "경상남도 사천시남해군하동군"
       },
       "parent_id": "Q41151"
     },
@@ -4155,7 +4155,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "울산광역시 울주군"
+        "lang:ko": "울산광역시 울주군"
       },
       "parent_id": "Q41278"
     },
@@ -4179,7 +4179,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "강원도 원주시을"
+        "lang:ko": "강원도 원주시을"
       },
       "parent_id": "Q41071"
     },
@@ -4203,7 +4203,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청북도 제천시단양군"
+        "lang:ko": "충청북도 제천시단양군"
       },
       "parent_id": "Q41066"
     },
@@ -4227,7 +4227,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 통영시고성군"
+        "lang:ko": "경상남도 통영시고성군"
       },
       "parent_id": "Q41151"
     },
@@ -4251,7 +4251,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 수원시을"
+        "lang:ko": "경기도 수원시을"
       },
       "parent_id": "Q20937"
     },
@@ -4275,7 +4275,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 진주시을"
+        "lang:ko": "경상남도 진주시을"
       },
       "parent_id": "Q41151"
     },
@@ -4299,7 +4299,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대전광역시 서구을"
+        "lang:ko": "대전광역시 서구을"
       },
       "parent_id": "Q20921"
     },
@@ -4323,7 +4323,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대전광역시 유성구을"
+        "lang:ko": "대전광역시 유성구을"
       },
       "parent_id": "Q20921"
     },
@@ -4347,7 +4347,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 군산시"
+        "lang:ko": "전라북도 군산시"
       },
       "parent_id": "Q41157"
     },
@@ -4371,7 +4371,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "울산광역시 남구을"
+        "lang:ko": "울산광역시 남구을"
       },
       "parent_id": "Q41278"
     },
@@ -4395,7 +4395,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청북도 청주시서원구"
+        "lang:ko": "충청북도 청주시서원구"
       },
       "parent_id": "Q41066"
     },
@@ -4419,7 +4419,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 파주시갑"
+        "lang:ko": "경기도 파주시갑"
       },
       "parent_id": "Q20937"
     },
@@ -4443,7 +4443,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 상주시군위군의성군청송군"
+        "lang:ko": "경상북도 상주시군위군의성군청송군"
       },
       "parent_id": "Q41154"
     },
@@ -4467,7 +4467,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 마포구을"
+        "lang:ko": "서울특별시 마포구을"
       },
       "parent_id": "Q8684"
     },
@@ -4491,7 +4491,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 동구을"
+        "lang:ko": "대구광역시 동구을"
       },
       "parent_id": "Q20927"
     },
@@ -4515,7 +4515,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 화성시갑"
+        "lang:ko": "경기도 화성시갑"
       },
       "parent_id": "Q20937"
     },
@@ -4539,7 +4539,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 서구을"
+        "lang:ko": "인천광역시 서구을"
       },
       "parent_id": "Q20934"
     },
@@ -4563,7 +4563,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 중랑구을"
+        "lang:ko": "서울특별시 중랑구을"
       },
       "parent_id": "Q8684"
     },
@@ -4587,7 +4587,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강남구갑"
+        "lang:ko": "서울특별시 강남구갑"
       },
       "parent_id": "Q8684"
     },
@@ -4611,7 +4611,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "울산광역시 남구갑"
+        "lang:ko": "울산광역시 남구갑"
       },
       "parent_id": "Q41278"
     },
@@ -4635,7 +4635,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 관악구을"
+        "lang:ko": "서울특별시 관악구을"
       },
       "parent_id": "Q8684"
     },
@@ -4659,7 +4659,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 여수시을"
+        "lang:ko": "전라남도 여수시을"
       },
       "parent_id": "Q41161"
     },
@@ -4683,7 +4683,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 남동구갑"
+        "lang:ko": "인천광역시 남동구갑"
       },
       "parent_id": "Q20934"
     },
@@ -4707,7 +4707,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 중구성동구을"
+        "lang:ko": "서울특별시 중구성동구을"
       },
       "parent_id": "Q8684"
     },
@@ -4731,7 +4731,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 고양시병"
+        "lang:ko": "경기도 고양시병"
       },
       "parent_id": "Q20937"
     },
@@ -4755,7 +4755,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 광주시갑"
+        "lang:ko": "경기도 광주시갑"
       },
       "parent_id": "Q20937"
     },
@@ -4779,7 +4779,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 달성군"
+        "lang:ko": "대구광역시 달성군"
       },
       "parent_id": "Q20927"
     },
@@ -4803,7 +4803,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 성남시수정구"
+        "lang:ko": "경기도 성남시수정구"
       },
       "parent_id": "Q20937"
     },
@@ -4827,7 +4827,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강서구병"
+        "lang:ko": "서울특별시 강서구병"
       },
       "parent_id": "Q8684"
     },
@@ -4851,7 +4851,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 수원시병"
+        "lang:ko": "경기도 수원시병"
       },
       "parent_id": "Q20937"
     },
@@ -4875,7 +4875,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 남구갑"
+        "lang:ko": "부산광역시 남구갑"
       },
       "parent_id": "Q16520"
     },
@@ -4899,7 +4899,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 김포시을"
+        "lang:ko": "경기도 김포시을"
       },
       "parent_id": "Q20937"
     },
@@ -4923,7 +4923,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 수성구을"
+        "lang:ko": "대구광역시 수성구을"
       },
       "parent_id": "Q20927"
     },
@@ -4947,7 +4947,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 부평구갑"
+        "lang:ko": "인천광역시 부평구갑"
       },
       "parent_id": "Q20934"
     },
@@ -4971,7 +4971,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 군포시갑"
+        "lang:ko": "경기도 군포시갑"
       },
       "parent_id": "Q20937"
     },
@@ -4995,7 +4995,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 남양주시병"
+        "lang:ko": "경기도 남양주시병"
       },
       "parent_id": "Q20937"
     },
@@ -5019,7 +5019,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 사하구갑"
+        "lang:ko": "부산광역시 사하구갑"
       },
       "parent_id": "Q16520"
     },
@@ -5043,7 +5043,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 양산시을"
+        "lang:ko": "경상남도 양산시을"
       },
       "parent_id": "Q41151"
     },
@@ -5067,7 +5067,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 화성시을"
+        "lang:ko": "경기도 화성시을"
       },
       "parent_id": "Q20937"
     },
@@ -5091,7 +5091,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "광주광역시 북구갑"
+        "lang:ko": "광주광역시 북구갑"
       },
       "parent_id": "Q41283"
     },
@@ -5115,7 +5115,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "광주광역시 서구을"
+        "lang:ko": "광주광역시 서구을"
       },
       "parent_id": "Q41283"
     },
@@ -5139,7 +5139,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 계양구갑"
+        "lang:ko": "인천광역시 계양구갑"
       },
       "parent_id": "Q20934"
     },
@@ -5163,7 +5163,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 수영구"
+        "lang:ko": "부산광역시 수영구"
       },
       "parent_id": "Q16520"
     },
@@ -5187,7 +5187,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 부천시소사구"
+        "lang:ko": "경기도 부천시소사구"
       },
       "parent_id": "Q20937"
     },
@@ -5211,7 +5211,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 기장군"
+        "lang:ko": "부산광역시 기장군"
       },
       "parent_id": "Q16520"
     },
@@ -5235,7 +5235,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 안산시상록구갑"
+        "lang:ko": "경기도 안산시상록구갑"
       },
       "parent_id": "Q20937"
     },
@@ -5259,7 +5259,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 나주시화순군"
+        "lang:ko": "전라남도 나주시화순군"
       },
       "parent_id": "Q41161"
     },
@@ -5283,7 +5283,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "강원도 홍천군철원군화천군양구군인제군"
+        "lang:ko": "강원도 홍천군철원군화천군양구군인제군"
       },
       "parent_id": "Q41071"
     },
@@ -5307,7 +5307,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 수원시갑"
+        "lang:ko": "경기도 수원시갑"
       },
       "parent_id": "Q20937"
     },
@@ -5331,7 +5331,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 시흥시을"
+        "lang:ko": "경기도 시흥시을"
       },
       "parent_id": "Q20937"
     },
@@ -5355,7 +5355,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 논산시계룡시금산군"
+        "lang:ko": "충청남도 논산시계룡시금산군"
       },
       "parent_id": "Q41070"
     },
@@ -5379,7 +5379,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 남양주시을"
+        "lang:ko": "경기도 남양주시을"
       },
       "parent_id": "Q20937"
     },
@@ -5403,7 +5403,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 천안시을"
+        "lang:ko": "충청남도 천안시을"
       },
       "parent_id": "Q41070"
     },
@@ -5427,7 +5427,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 용인시을"
+        "lang:ko": "경기도 용인시을"
       },
       "parent_id": "Q20937"
     },
@@ -5451,7 +5451,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 파주시을"
+        "lang:ko": "경기도 파주시을"
       },
       "parent_id": "Q20937"
     },
@@ -5475,7 +5475,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "광주광역시 동구남구을"
+        "lang:ko": "광주광역시 동구남구을"
       },
       "parent_id": "Q41283"
     },
@@ -5499,7 +5499,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 용인시갑"
+        "lang:ko": "경기도 용인시갑"
       },
       "parent_id": "Q20937"
     },
@@ -5523,7 +5523,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 남구갑"
+        "lang:ko": "인천광역시 남구갑"
       },
       "parent_id": "Q20934"
     },
@@ -5547,7 +5547,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 창원시진해구"
+        "lang:ko": "경상남도 창원시진해구"
       },
       "parent_id": "Q41151"
     },
@@ -5571,7 +5571,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라북도 정읍시고창군"
+        "lang:ko": "전라북도 정읍시고창군"
       },
       "parent_id": "Q41157"
     },
@@ -5595,7 +5595,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "광주광역시 광산구을"
+        "lang:ko": "광주광역시 광산구을"
       },
       "parent_id": "Q41283"
     },
@@ -5619,7 +5619,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 고양시정"
+        "lang:ko": "경기도 고양시정"
       },
       "parent_id": "Q20937"
     },
@@ -5643,7 +5643,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 구미시갑"
+        "lang:ko": "경상북도 구미시갑"
       },
       "parent_id": "Q41154"
     },
@@ -5667,7 +5667,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 서구갑"
+        "lang:ko": "인천광역시 서구갑"
       },
       "parent_id": "Q20934"
     },
@@ -5691,7 +5691,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 양천구을"
+        "lang:ko": "서울특별시 양천구을"
       },
       "parent_id": "Q8684"
     },
@@ -5715,7 +5715,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 광양시곡성군구례군"
+        "lang:ko": "전라남도 광양시곡성군구례군"
       },
       "parent_id": "Q41161"
     },
@@ -5739,7 +5739,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 경산시"
+        "lang:ko": "경상북도 경산시"
       },
       "parent_id": "Q41154"
     },
@@ -5763,7 +5763,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 밀양시의령군함안군창녕군"
+        "lang:ko": "경상남도 밀양시의령군함안군창녕군"
       },
       "parent_id": "Q41151"
     },
@@ -5787,7 +5787,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 관악구갑"
+        "lang:ko": "서울특별시 관악구갑"
       },
       "parent_id": "Q8684"
     },
@@ -5811,7 +5811,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 남동구을"
+        "lang:ko": "인천광역시 남동구을"
       },
       "parent_id": "Q20934"
     },
@@ -5835,7 +5835,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 동래구"
+        "lang:ko": "부산광역시 동래구"
       },
       "parent_id": "Q16520"
     },
@@ -5859,7 +5859,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 아산시갑"
+        "lang:ko": "충청남도 아산시갑"
       },
       "parent_id": "Q41070"
     },
@@ -5883,7 +5883,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 김천시"
+        "lang:ko": "경상북도 김천시"
       },
       "parent_id": "Q41154"
     },
@@ -5907,7 +5907,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 서대문구을"
+        "lang:ko": "서울특별시 서대문구을"
       },
       "parent_id": "Q8684"
     },
@@ -5931,7 +5931,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 창원시의창구"
+        "lang:ko": "경상남도 창원시의창구"
       },
       "parent_id": "Q41151"
     },
@@ -5955,7 +5955,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 수원시무"
+        "lang:ko": "경기도 수원시무"
       },
       "parent_id": "Q20937"
     },
@@ -5979,7 +5979,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 포천시가평군"
+        "lang:ko": "경기도 포천시가평군"
       },
       "parent_id": "Q20937"
     },
@@ -6003,7 +6003,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 평택시을"
+        "lang:ko": "경기도 평택시을"
       },
       "parent_id": "Q20937"
     },
@@ -6027,7 +6027,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 양산시갑"
+        "lang:ko": "경상남도 양산시갑"
       },
       "parent_id": "Q41151"
     },
@@ -6051,7 +6051,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 은평구을"
+        "lang:ko": "서울특별시 은평구을"
       },
       "parent_id": "Q8684"
     },
@@ -6075,7 +6075,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "강원도 춘천시"
+        "lang:ko": "강원도 춘천시"
       },
       "parent_id": "Q41071"
     },
@@ -6099,7 +6099,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강남구을"
+        "lang:ko": "서울특별시 강남구을"
       },
       "parent_id": "Q8684"
     },
@@ -6123,7 +6123,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 중구남구"
+        "lang:ko": "대구광역시 중구남구"
       },
       "parent_id": "Q20927"
     },
@@ -6147,7 +6147,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 용인시정"
+        "lang:ko": "경기도 용인시정"
       },
       "parent_id": "Q20937"
     },
@@ -6171,7 +6171,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 안산시상록구을"
+        "lang:ko": "경기도 안산시상록구을"
       },
       "parent_id": "Q20937"
     },
@@ -6195,7 +6195,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청북도 충주시"
+        "lang:ko": "충청북도 충주시"
       },
       "parent_id": "Q41066"
     },
@@ -6219,7 +6219,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 홍성군예산군"
+        "lang:ko": "충청남도 홍성군예산군"
       },
       "parent_id": "Q41070"
     },
@@ -6243,7 +6243,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 도봉구을"
+        "lang:ko": "서울특별시 도봉구을"
       },
       "parent_id": "Q8684"
     },
@@ -6267,7 +6267,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 강서구갑"
+        "lang:ko": "서울특별시 강서구갑"
       },
       "parent_id": "Q8684"
     },
@@ -6291,7 +6291,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 고양시을"
+        "lang:ko": "경기도 고양시을"
       },
       "parent_id": "Q20937"
     },
@@ -6315,7 +6315,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 북구강서구을"
+        "lang:ko": "부산광역시 북구강서구을"
       },
       "parent_id": "Q16520"
     },
@@ -6339,7 +6339,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 남구을"
+        "lang:ko": "인천광역시 남구을"
       },
       "parent_id": "Q20934"
     },
@@ -6363,7 +6363,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "충청남도 아산시을"
+        "lang:ko": "충청남도 아산시을"
       },
       "parent_id": "Q41070"
     },
@@ -6387,7 +6387,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "부산광역시 해운대구갑"
+        "lang:ko": "부산광역시 해운대구갑"
       },
       "parent_id": "Q16520"
     },
@@ -6411,7 +6411,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 산청군함양군거창군합천군"
+        "lang:ko": "경상남도 산청군함양군거창군합천군"
       },
       "parent_id": "Q41151"
     },
@@ -6435,7 +6435,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "전라남도 해남군완도군진도군"
+        "lang:ko": "전라남도 해남군완도군진도군"
       },
       "parent_id": "Q41161"
     },
@@ -6459,7 +6459,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "인천광역시 연수구갑"
+        "lang:ko": "인천광역시 연수구갑"
       },
       "parent_id": "Q20934"
     },
@@ -6483,8 +6483,8 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "비례대표 국회의원 선거구",
-        "lang:en_US": "PR assembly constituency in South Korea"
+        "lang:ko": "비례대표 국회의원 선거구",
+        "lang:en": "PR assembly constituency in South Korea"
       },
       "parent_id": null
     },
@@ -6508,7 +6508,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "제주특별자치도 서귀포시"
+        "lang:ko": "제주특별자치도 서귀포시"
       },
       "parent_id": "Q41164"
     },
@@ -6532,7 +6532,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "울산광역시 동구"
+        "lang:ko": "울산광역시 동구"
       },
       "parent_id": "Q41278"
     },
@@ -6556,7 +6556,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상남도 거제시"
+        "lang:ko": "경상남도 거제시"
       },
       "parent_id": "Q41151"
     },
@@ -6580,7 +6580,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경상북도 경주시"
+        "lang:ko": "경상북도 경주시"
       },
       "parent_id": "Q41154"
     },
@@ -6604,7 +6604,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 구리시"
+        "lang:ko": "경기도 구리시"
       },
       "parent_id": "Q20937"
     },
@@ -6628,7 +6628,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "경기도 하남시"
+        "lang:ko": "경기도 하남시"
       },
       "parent_id": "Q20937"
     },
@@ -6652,7 +6652,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "울산광역시 북구"
+        "lang:ko": "울산광역시 북구"
       },
       "parent_id": "Q41278"
     },
@@ -6676,7 +6676,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "서울특별시 용산구"
+        "lang:ko": "서울특별시 용산구"
       },
       "parent_id": "Q8684"
     },
@@ -6700,7 +6700,7 @@
         "lang:en": "Constituency of the National Assembly of South Korea"
       },
       "name": {
-        "lang:ko_KR": "대구광역시 서구"
+        "lang:ko": "대구광역시 서구"
       },
       "parent_id": "Q20927"
     },
@@ -6724,8 +6724,8 @@
         "lang:en": "special city of South Korea"
       },
       "name": {
-        "lang:en_US": "Seoul",
-        "lang:ko_KR": "서울특별시"
+        "lang:en": "Seoul",
+        "lang:ko": "서울특별시"
       },
       "parent_id": "Q884"
     },
@@ -6748,8 +6748,8 @@
         "lang:en": "country"
       },
       "name": {
-        "lang:ko_KR": "대한민국",
-        "lang:en_US": "Republic of Korea"
+        "lang:ko": "대한민국",
+        "lang:en": "Republic of Korea"
       },
       "parent_id": null
     }


### PR DESCRIPTION
I forgot to update `boundaries/build/index.json` with the new language codes when moving to Wikidata codes in aa306b0, so this fixes that. Confirmed that none of the old codes are now present in the repo.